### PR TITLE
プリセット周りの機能を追加

### DIFF
--- a/app/assets/stylesheets/profiles.scss
+++ b/app/assets/stylesheets/profiles.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the profiles controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,12 @@ class ApplicationController < ActionController::Base
   before_action :require_login
   
   private
+
   def not_authenticated
     redirect_to login_path
+  end
+
+  def preset_record_not_found
+    redirect_to presets_path, alert: t('defaults.record_not_found')
   end
 end

--- a/app/controllers/item_categories_controller.rb
+++ b/app/controllers/item_categories_controller.rb
@@ -1,0 +1,44 @@
+class ItemCategoriesController < ApplicationController
+  before_action :set_preset
+  rescue_from ActiveRecord::RecordNotFound, with: :preset_record_not_found
+
+  def index
+    @item_categories = @preset.item_categories.all.order(:created_at)
+    @item_category = @preset.item_categories.new
+  end
+
+  def create
+    @item_category = @preset.item_categories.new(category_params)
+    if @item_category.save
+      redirect_to preset_item_categories_path(@preset), notice: t('.success', name: @item_category.item_category_name)
+    else
+      redirect_to preset_item_categories_path(@preset), alert: t('.fail')
+    end
+  end
+
+  def update
+    @item_category = @preset.item_categories.find(params[:id])
+    if @item_category.update(category_params)
+      redirect_to preset_item_categories_path(@preset), notice: t('.success', name: @item_category.item_category_name)
+    else
+      redirect_to preset_item_categories_path(@preset), alert: t('.fail', name:  ItemCategory.find(@item_category.id).item_category_name)
+    end
+  end
+
+  def destroy
+    @item_category = @preset.item_categories.find(params[:id])
+    name = @item_category.item_category_name
+    @item_category.destroy!
+    redirect_to preset_item_categories_path(@preset), notice: t('.success', name: name)
+  end
+
+  private
+
+  def set_preset
+    @preset = current_user.presets.find(params[:preset_id])
+  end
+  
+  def category_params
+    params.require(:item_category).permit(:item_category_name)
+  end
+end

--- a/app/controllers/preset_items_controller.rb
+++ b/app/controllers/preset_items_controller.rb
@@ -1,0 +1,50 @@
+class PresetItemsController < ApplicationController
+  before_action :set_preset
+  rescue_from ActiveRecord::RecordNotFound, with: :preset_record_not_found
+
+  def new
+    redirect_to preset_item_categories_path(@preset), alert: t('.category_less_alert') unless @preset.item_categories.present?
+    @preset_item = PresetItem.new
+  end
+
+  def create
+    @preset_item = PresetItem.new(item_params)
+    if @preset_item.save
+      redirect_to preset_path(@preset), notice: t('.success', item_name: @preset_item.preset_item_name, category_name: @preset_item.item_category.item_category_name)
+    else
+      flash.now[:alert] = t('.fail')
+      render :new
+    end
+  end
+
+  def edit
+    @preset_item = PresetItem.find(params[:id])
+  end
+
+  def update
+    @preset_item = PresetItem.find(params[:id])
+    if @preset_item.update(item_params)
+      redirect_to preset_path(@preset), notice: t('.success', name: @preset_item.preset_item_name)
+    else
+      flash.now[:alert] = t('.fail', name: PresetItem.find(@preset_item.id).preset_item_name)
+      render :edit
+    end
+  end
+
+  def destroy
+    @preset_item = PresetItem.find(params[:id])
+    name = @preset_item.preset_item_name
+    @preset_item.destroy!
+    redirect_to preset_path(@preset), notice: t('.success', name: name)
+  end
+
+  private
+
+  def set_preset
+    @preset = current_user.presets.find(params[:preset_id])
+  end
+
+  def item_params
+    params.require(:preset_item).permit(:item_category_id, :preset_item_name)
+  end
+end

--- a/app/controllers/presets_controller.rb
+++ b/app/controllers/presets_controller.rb
@@ -1,0 +1,54 @@
+class PresetsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :preset_record_not_found
+
+  def index
+    @q = current_user.presets.ransack(params[:q])
+    @presets = @q.result.order(:created_at).page(params[:page])
+  end
+
+  def new
+    @preset = Preset.new
+  end
+
+  def create
+    @preset = current_user.presets.new(preset_params)
+    if @preset.save
+      redirect_to preset_path(@preset), notice: t('.success', name: @preset.preset_name)
+    else
+      flash.now[:alert] = t('.fail')
+      render :new
+    end
+  end
+
+  def show
+    @preset = current_user.presets.find(params[:id])
+    @item_categories = @preset.item_categories.includes(:preset_items).order(:created_at)
+  end
+
+  def edit
+    @preset = current_user.presets.find(params[:id])
+  end
+
+  def update
+    @preset = current_user.presets.find(params[:id])
+    if @preset.update(preset_params)
+      redirect_to preset_path(@preset), notice: t('.success', name: @preset.preset_name)
+    else
+      flash.now[:alert] = t('.fail')
+      render :edit
+    end
+  end
+
+  def destroy
+    @preset = current_user.presets.find(params[:id])
+    name = @preset.preset_name
+    @preset.destroy!
+    redirect_to presets_path, notice: t('.success', name: name)
+  end
+
+  private
+
+  def preset_params
+    params.require(:preset).permit(:preset_name)
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -14,7 +14,7 @@ class ProfilesController < ApplicationController
     end
   end
 
-  def new; end
+  def password_reset; end
 
   def create
     @user.deliver_reset_password_instructions! if @user

--- a/app/helpers/item_categories_helper.rb
+++ b/app/helpers/item_categories_helper.rb
@@ -1,0 +1,5 @@
+module ItemCategoriesHelper
+  def item_category_exists?(item_category)
+    ItemCategory.exists?(id: item_category.id)
+  end
+end

--- a/app/helpers/mypages_helper.rb
+++ b/app/helpers/mypages_helper.rb
@@ -1,2 +1,0 @@
-module MypagesHelper
-end

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,2 +1,0 @@
-module PasswordResetsHelper
-end

--- a/app/helpers/preset_items_helper.rb
+++ b/app/helpers/preset_items_helper.rb
@@ -1,0 +1,5 @@
+module PresetItemsHelper
+  def preset_item__exists?(preset_item)
+    PresetItem.exists?(id: preset_item.id)
+  end
+end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,2 +1,0 @@
-module ProfilesHelper
-end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,2 +1,0 @@
-module StaticPagesHelper
-end

--- a/app/helpers/user_sessions_helper.rb
+++ b/app/helpers/user_sessions_helper.rb
@@ -1,2 +1,0 @@
-module UserSessionsHelper
-end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,0 @@
-module UsersHelper
-end

--- a/app/models/item_category.rb
+++ b/app/models/item_category.rb
@@ -1,0 +1,6 @@
+class ItemCategory < ApplicationRecord
+  belongs_to :preset
+  has_many :preset_items, dependent: :destroy
+
+  validates :item_category_name, presence: true, uniqueness: { scope: :preset_id }
+end

--- a/app/models/preset.rb
+++ b/app/models/preset.rb
@@ -1,0 +1,12 @@
+class Preset < ApplicationRecord
+  belongs_to :user
+  has_many :item_categories, dependent: :destroy
+
+  validates :preset_name, presence: true
+
+  private
+
+  def self.ransackable_attributes(auth_object = nil)
+    ['preset_name']
+  end
+end

--- a/app/models/preset_item.rb
+++ b/app/models/preset_item.rb
@@ -1,0 +1,5 @@
+class PresetItem < ApplicationRecord
+  belongs_to :item_category
+
+  validates :preset_item_name, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  
+  has_many :presets
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/item_categories/_preset_category_form.html.erb
+++ b/app/views/item_categories/_preset_category_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_with model: [preset, item_category], local: true do |f| %>
+  <div class = "category<%= item_category.id %>">
+  <div class = 'field'>
+    <%= f.text_field :item_category_name %>
+  </div>
+  <div class = 'actions'>
+    <%= f.submit %>
+    <% if item_category_exists?(item_category) %>
+      <%= link_to t('defaults.destroy'), preset_item_category_path(preset, item_category), method: :delete, data: {confirm: t('defaults.category_destroy_confirm', name: item_category.item_category_name)} %>
+    <% end %>
+  </div>
+  <br>
+  </div>
+<% end %>

--- a/app/views/item_categories/index.html.erb
+++ b/app/views/item_categories/index.html.erb
@@ -1,0 +1,8 @@
+<h1><%= t('.title') %></h1>
+
+<p><%= ItemCategory.human_attribute_name(:item_category_name) %></p>
+<% if @item_categories.present? %>
+  <%= render partial: 'preset_category_form', collection: @item_categories, as: 'item_category', locals: { preset: @preset } %>
+<% end %>
+
+<%= render 'preset_category_form', { item_category: @item_category, preset: @preset } %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -14,6 +14,6 @@
     <%= f.password_field :password_confirmation %>
   </div>
   <div class="actions">
-    <%= f.submit t('default.update') %>
+    <%= f.submit %>
   </div>
 <% end %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -3,6 +3,6 @@
   <div class="field">
     <%= form.label t('.user_email') %><br />
     <%= form.text_field :email %>
-    <%= form.submit t('default.send') %>
+    <%= form.submit t('defaults.send') %>
   </div>
 <% end %>

--- a/app/views/preset_items/_preset_item_form.html.erb
+++ b/app/views/preset_items/_preset_item_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with model: [preset, preset_item], local: true do |f| %>
+  <%= render 'shared/error_messages', model: preset_item %>
+  <div class = 'field'>
+    <%= f.label ItemCategory.human_attribute_name(:item_category_name) %><br />
+    <%= f.collection_select :item_category_id, preset.item_categories, :id, :item_category_name %>
+  </div>
+  <div class = 'field'>
+    <%= f.label :preset_item_name %><br />
+    <%= f.text_field :preset_item_name %>
+  </div>
+  <div class = 'actions'>
+    <%= f.submit %>
+    <% if preset_item__exists?(preset_item) %>
+      <%= link_to t('defaults.destroy'), preset_preset_item_path(preset, preset_item), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: preset_item.preset_item_name)} %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/preset_items/edit.html.erb
+++ b/app/views/preset_items/edit.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'preset_item_form', { preset: @preset, preset_item: @preset_item } %>

--- a/app/views/preset_items/new.html.erb
+++ b/app/views/preset_items/new.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'preset_item_form', { preset: @preset, preset_item: @preset_item } %>

--- a/app/views/presets/_preset_name_form.html.erb
+++ b/app/views/presets/_preset_name_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_with model: preset, local: true do |f| %>
+  <%= render 'shared/error_messages', model: preset %>
+  <div class = 'field'>
+    <%= f.label :preset_name %><br />
+    <%= f.text_field :preset_name %>
+  </div>
+  <div class = 'actions'>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/presets/_search.html.erb
+++ b/app/views/presets/_search.html.erb
@@ -1,0 +1,4 @@
+<%= search_form_for @q, url: url do |f| %>
+  <%= f.search_field :preset_name_cont, class: 'form-control', placeholder: true %>
+  <%= f.submit t('defaults.search'), class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/presets/edit.html.erb
+++ b/app/views/presets/edit.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t('.title') %></h1>
+
+<%= render 'preset_name_form', preset: @preset %>

--- a/app/views/presets/index.html.erb
+++ b/app/views/presets/index.html.erb
@@ -1,0 +1,19 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'search', q: @q, url: presets_path %>
+
+<%= link_to t('presets.new.title'), new_preset_path %>
+<br>
+<br>
+
+<% if @presets.present? %>
+  <% @presets.each do |preset| %>
+    <%= preset.preset_name %>
+    <%= link_to t('defaults.show'), preset_path(preset) %>
+    <%= link_to t('defaults.destroy'), preset_path(preset), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: preset.preset_name)} %>
+    <br>
+  <% end %>
+  <%= paginate @presets %>
+<% else %>
+  <p><%= t '.preset_less' %></p>
+<% end %>

--- a/app/views/presets/new.html.erb
+++ b/app/views/presets/new.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'preset_name_form', preset: @preset %>

--- a/app/views/presets/show.html.erb
+++ b/app/views/presets/show.html.erb
@@ -1,0 +1,35 @@
+<h1><%= t('.title') %></h1>
+
+<%= @preset.preset_name %>
+<%= link_to t('presets.edit.title'), edit_preset_path(@preset) %>
+<%= link_to t('.preset_destroy'), preset_path(@preset), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: @preset.preset_name)} %>
+<br>
+<br>
+<%= link_to t('.category_index'), preset_item_categories_path(@preset) %>
+<%= link_to t('.item_new'), new_preset_preset_item_path(@preset) %>
+<br>
+<br>
+<% if @item_categories.present? %>
+  <% @item_categories.each do |item_category| %>
+    <div class = "category<%= item_category.id %>">
+      <%= item_category.item_category_name %>
+      <br>
+      <br>
+      <% if item_category.preset_items.present? %>
+        <% item_category.preset_items.each do |preset_item| %>
+          <div class = "item<%= preset_item.id %>">
+            <%= preset_item.preset_item_name %>
+            <%= link_to t('defaults.edit'), edit_preset_preset_item_path(@preset, preset_item) %>
+            <%= link_to t('defaults.destroy'), preset_preset_item_path(@preset, preset_item), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: preset_item.preset_item_name)} %>
+            <br>
+            <br>
+          </div>
+        <% end %>
+      <% else %>
+        <p><%= t '.item_less' %></p>
+      <% end %>
+    </div>
+  <% end %>
+<% else %>
+  <p><%= t '.category_less' %></p>
+<% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -11,6 +11,6 @@
     <%= f.text_field :email %>
   </div>
   <div class = 'actions'>
-    <%= f.submit t('default.update') %>
+    <%= f.submit %>
   </div>
 <% end %>

--- a/app/views/profiles/password_reset.html.erb
+++ b/app/views/profiles/password_reset.html.erb
@@ -5,4 +5,4 @@
 <p><%= User.human_attribute_name(:email) %></p>
 <%= @user.email %>
 <br>
-<%= link_to t('default.send'), profile_path, method: :post %>
+<%= link_to t('defaults.send'), profile_path, method: :post %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -6,4 +6,4 @@
 <%= @user.email %>
 <br>
 <%= link_to t('profiles.edit.title'), edit_profile_path %>
-<%= link_to t('profiles.new.title'), new_profile_path %>
+<%= link_to t('profiles.password_reset.title'), password_reset_profile_path %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,19 +1,19 @@
 <header class="sticky-top">
-  <h1><%= link_to t('default.app_name'), root_path %></h1>
+  <h1><%= link_to t('defaults.app_name'), root_path %></h1>
   <div align = 'right'>
   <% if logged_in? %>
     <li>
       <%= link_to t('profiles.show.title'), profile_path %>
     </li>
     <li>
-      <%= link_to t('default.logout'), logout_path, method: :delete %>
+      <%= link_to t('defaults.logout'), logout_path, method: :delete %>
      </li>
   <% else %>
     <li>
-       <%= link_to t('default.singin'), new_user_path %>
+       <%= link_to t('defaults.singin'), new_user_path %>
     </li>
     <li>
-       <%= link_to t('default.login'), login_path %>
+       <%= link_to t('defaults.login'), login_path %>
      </li>
   <% end %>
   </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,6 +1,6 @@
 <div>
-  <%= link_to t('default.preset'), '#' %>
-  <%= link_to t('default.inventory_list'), '#' %>
-  <%= link_to t('default.purchase_list'), '#' %>
-  <%= link_to t('default.schedule'), '#' %>
+  <%= link_to t('defaults.preset'), presets_path %>
+  <%= link_to t('defaults.inventory_list'), '#' %>
+  <%= link_to t('defaults.purchase_list'), '#' %>
+  <%= link_to t('defaults.schedule'), '#' %>
 </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -10,8 +10,8 @@
     <%= f.password_field :password %>
   </div>
   <div class = 'actions'>
-    <%= f.submit t('default.login') %>
+    <%= f.submit t('defaults.login') %>
   </div>
 <% end %>
 <%= link_to t('.forget_password'), new_password_reset_path %>
-<%= link_to t('default.singin'), new_user_path %>
+<%= link_to t('defaults.singin'), new_user_path %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -19,8 +19,8 @@
     <%= f.password_field :password_confirmation %>
   </div>
   <div class = 'actions'>
-    <%= f.submit t('default.register') %>
+    <%= f.submit t('defaults.register') %>
   </div>
 <% end %>
 
-<%= link_to t('default.login'), login_path %>
+<%= link_to t('defaults.login'), login_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,10 +34,12 @@ module EnjoyAHobby
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     # config.eager_load_paths << Rails.root.join("extras")
-
+    config.action_controller.include_all_helpers = false
     # Don't generate system test files.
     config.generators.system_tests = nil
     config.generators do |g|
+      g.assets false
+      g.skip_routes true
       g.test_framework false
     end
   end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 15
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -2,13 +2,25 @@ ja:
   activerecord:
     models:
       user: 'ユーザー'
+      preset: 'プリセット'
+      item_category: 'カテゴリー'
+      preset_item: '持ち物'
     attributes:
       user:
-        id: 'ID'
+        id: 'ユーザーID'
         user_name: 'ユーザーネーム'
         email: 'メールアドレス'
         password: 'パスワード'
         password_confirmation: 'パスワード確認'
+      preset:
+        id: 'プリセットID'
+        preset_name: 'プリセット名'
+      item_category:
+        id: 'カテゴリーID'
+        item_category_name: 'カテゴリー名'
+      preset_item:
+        id: 'プリセットアイテムID'
+        preset_item_name: '持ち物名'
   attributes:
     created_at: '作成日'
     updates_at: '更新日'

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -1,16 +1,30 @@
 ja:
-  default:
+  defaults:
     app_name: 'LIVE Pl@nning'
     singin: 'ユーザー登録'
     login: 'ログイン'
     logout: 'ログアウト'
+    show: '詳細'
+    edit: '編集'
+    destroy: '削除'
+    destroy_confirm: "%{name}を削除してよろしいですか?"
+    category_destroy_confirm: "カテゴリーを削除すると、そのカテゴリーの持ち物も削除されます。%{name}を削除してよろしいですか?"
     register: '登録'
     send: '送信'
-    update: '更新'
+    save: '保存'
+    search: '検索'
+    record_not_found: 'アクセスしたページは存在しません'
     preset: 'プリセット'
     inventory_list: '持ち物リスト'
     purchase_list: '物販購入リスト'
     schedule: 'スケジュール'
+  helpers:
+    submit:
+      create: '作成'
+      update: '更新'
+    placeholder:
+      q:
+        preset_name_cont: '検索ワード'
   users:
     new:
       title: 'ユーザー登録'
@@ -39,23 +53,52 @@ ja:
       changed_password: 'パスワードを変更しました'
   presets:
     index:
+      title: 'プリセット一覧'
+      preset_less: 'プリセットがありません'
     new:
+      title: 'プリセット作成'
     create:
+      success: "%{name}を作成しました"
+      fail: 'プリセットの作成に失敗しました'
     show:
+      title: 'プリセット詳細'
+      preset_destroy: 'プリセット削除'
+      category_index: 'カテゴリーの追加・編集・削除'
+      item_new: '持ち物の追加'
+      category_less: '登録されたカテゴリーがありません'
+      item_less: 'このカテゴリーに登録された持ち物はありません'
     edit:
+      title: 'プリセット名編集'
     update:
+      success: "プリセット名を%{name}に変更しました"
+      fail: 'プリセット名の変更に失敗しました'
     destroy:
+      success: "%{name}を削除しました"
   item_categories:
-    edit:
+    index:
+      title: 'カテゴリー編集'
     create:
+      success: "%{name}を作成しました"
+      fail: 'カテゴリーの作成に失敗しました'
     update:
+      success: "カテゴリー名を%{name}に更新しました"
+      fail: "%{name}のカテゴリー名の変更に失敗しました"
     destroy:
+      success: "%{name}を削除しました"
   preset_items:
     new:
+      title: '持ち物追加'
+      category_less_alert: '持ち物の追加を行う場合、先にカテゴリーを1つ以上登録をしてください'
     create:
+      success: "%{item_name}を%{category_name}に追加しました"
+      fail: '持ち物の作成に失敗しました'
     edit:
+      title: '持ち物編集'
     update:
+      success: "%{name}の情報を更新しました"
+      fail: "%{name}の情報の更新に失敗しました"
     destroy:
+      success: "%{name}を削除しました"
   profiles:
     show:
       title: 'プロフィール'
@@ -65,7 +108,7 @@ ja:
     update:
       success: 'プロフィールを変更しました'
       fail: 'プロフィールの編集に失敗しました'
-    new:
+    password_reset:
       title: 'パスワード変更用メール送信'
       explanatory: '登録されているメールアドレスにパスワード変更用の
 メールを送信します。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,21 @@
 Rails.application.routes.draw do
-  get 'profiles/edit'
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
   
-  get 'password_resets/edit'
   root 'static_pages#top'
-
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
-
   get 'mypage', to: 'mypages#index'
+
   resources :users, only: %i[new create]
   resources :password_resets, only: %i[new create edit update]
-  resource :profile, only: %i[show edit update new create]
+  resource :profile, only: %i[show edit update create] do
+    get 'password_reset', on: :collection
+  end
+  resources :presets do
+    resources :item_categories, only: %i[index create update destroy]
+    resources :preset_items, only: %i[new create edit update destroy]
+  end
 end

--- a/db/migrate/20230313111556_create_presets.rb
+++ b/db/migrate/20230313111556_create_presets.rb
@@ -1,0 +1,10 @@
+class CreatePresets < ActiveRecord::Migration[6.1]
+  def change
+    create_table :presets do |t|
+      t.string :preset_name, null: false
+      t.belongs_to :user, index: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230313112100_create_item_categories.rb
+++ b/db/migrate/20230313112100_create_item_categories.rb
@@ -1,0 +1,11 @@
+class CreateItemCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :item_categories do |t|
+      t.string :item_category_name, null: false
+      t.belongs_to :preset, index: true, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :item_categories, [:item_category_name, :preset_id], unique: true
+  end
+end

--- a/db/migrate/20230313112238_create_preset_items.rb
+++ b/db/migrate/20230313112238_create_preset_items.rb
@@ -1,0 +1,10 @@
+class CreatePresetItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :preset_items do |t|
+      t.string :preset_item_name, null: false
+      t.belongs_to :item_category, index: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_07_103108) do
+ActiveRecord::Schema.define(version: 2023_03_13_112238) do
+
+  create_table "item_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "item_category_name", null: false
+    t.bigint "preset_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_category_name", "preset_id"], name: "index_item_categories_on_item_category_name_and_preset_id", unique: true
+    t.index ["preset_id"], name: "index_item_categories_on_preset_id"
+  end
+
+  create_table "preset_items", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "preset_item_name", null: false
+    t.bigint "item_category_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_category_id"], name: "index_preset_items_on_item_category_id"
+  end
+
+  create_table "presets", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "preset_name", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_presets_on_user_id"
+  end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "user_name", null: false
@@ -27,4 +52,7 @@ ActiveRecord::Schema.define(version: 2023_03_07_103108) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
+  add_foreign_key "item_categories", "presets"
+  add_foreign_key "preset_items", "item_categories"
+  add_foreign_key "presets", "users"
 end

--- a/spec/factories/item_categories.rb
+++ b/spec/factories/item_categories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :item_category do
+    sequence(:item_category_name) { |n| "プリセットカテゴリー#{n}" }
+    association :preset
+  end
+end

--- a/spec/factories/preset_items.rb
+++ b/spec/factories/preset_items.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :preset_item do
+    sequence(:preset_item_name) { |n| "プリセットアイテム#{n}" }
+    association :item_category
+  end
+end

--- a/spec/factories/presets.rb
+++ b/spec/factories/presets.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :preset do
+    sequence(:preset_name) { |n| "プリセット#{n}" }
+    association :user
+  end
+end

--- a/spec/models/item_category_spec.rb
+++ b/spec/models/item_category_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe ItemCategory, type: :model do
+  describe 'のバリデーションが' do
+    it 'すべてのアトリビュートに適用されない' do
+      item_category = build(:item_category)
+      expect(item_category).to be_valid
+      expect(item_category.errors).to be_empty
+    end
+    it 'カテゴリー名がない場合に適用される' do
+      name_less_item_category = build(:item_category, item_category_name: '')
+      expect(name_less_item_category).not_to be_valid
+      expect(name_less_item_category.errors).not_to be_empty
+    end
+    it '同一プリセット内に存在するカテゴリー名の場合に適用される' do
+      preset = create(:preset)
+      item_category = create(:item_category, preset: preset)
+      another_item_category = build(:item_category, item_category_name: item_category.item_category_name, preset: preset)
+      expect(another_item_category).not_to be_valid
+      expect(another_item_category.errors).not_to be_empty
+    end
+    it '別プリセット内に存在し、同一プリセット内には存在しないカテゴリー名の場合に適用されない' do
+      item_category = create(:item_category)
+      another_item_category = build(:item_category, item_category_name: item_category.item_category_name)
+      expect(item_category).to be_valid
+      expect(item_category.errors).to be_empty
+    end
+  end
+end

--- a/spec/models/preset_item_spec.rb
+++ b/spec/models/preset_item_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe PresetItem, type: :model do
+  describe 'のバリデーションが' do
+    it 'すべてのアトリビュートに適用されない' do
+      preset_item = build(:preset_item)
+      expect(preset_item).to be_valid
+      expect(preset_item.errors).to be_empty
+    end
+    it '持ち物名がない場合に適用される' do
+      name_less_preset_item = build(:preset_item, preset_item_name: '')
+      expect(name_less_preset_item).not_to be_valid
+      expect(name_less_preset_item.errors).not_to be_empty
+    end
+  end
+end

--- a/spec/models/preset_spec.rb
+++ b/spec/models/preset_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Preset, type: :model do
+  describe 'のバリデーションが' do
+    it 'すべてのアトリビュートに適用されない' do
+      preset = build(:preset)
+      expect(preset).to be_valid
+      expect(preset.errors).to be_empty
+    end
+    it 'プリセット名がない場合に適用される' do
+      name_less_preset = build(:preset, preset_name: '')
+      expect(name_less_preset).not_to be_valid
+      expect(name_less_preset.errors).not_to be_empty
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,9 @@ RSpec.configure do |config|
     # strategyがtransactionなので、rollbackする
     DatabaseCleaner.clean
   end
+  config.after(:all) do
+    DatabaseCleaner.clean
+  end
 
   config.include FactoryBot::Syntax::Methods
   config.include LoginModule

--- a/spec/system/item_categories_spec.rb
+++ b/spec/system/item_categories_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe 'ItemCategories', type: :system do
+  describe 'プリセット用カテゴリー' do
+    let!(:user) { create(:user) }
+    let!(:preset) { create(:preset, user: user) }
+    before { login(user) }
+    context 'カテゴリー編集ページ' do
+      context 'カテゴリー作成' do
+        context 'フォームの入力値が正常' do
+          it 'カテゴリーの作成に成功する' do
+            visit preset_item_categories_path(preset)
+            fill_in 'item_category_item_category_name', with: 'category_1'
+            click_button '作成'
+            expect(current_path).to eq preset_item_categories_path(preset)
+            expect(page).to have_content 'category_1を作成しました'
+            visit preset_path(preset)
+            expect(page).to have_content 'category_1'
+            expect(page).not_to have_content '登録されたカテゴリーがありません'
+          end
+        end
+        context 'カテゴリー名が未入力' do
+          it 'カテゴリーの作成に失敗する' do
+            visit preset_item_categories_path(preset)
+            fill_in 'item_category_item_category_name', with: ''
+            click_button '作成'
+            expect(current_path).to eq preset_item_categories_path(preset)
+            expect(page).to have_content 'カテゴリーの作成に失敗しました'
+            visit preset_path(preset)
+            expect(page).to have_content '登録されたカテゴリーがありません'
+          end
+        end
+        context '既存のカテゴリー名と同じカテゴリー名が入力' do
+          let!(:category) { create(:item_category, preset: preset) }
+          it 'カテゴリーの作成に失敗する' do
+            visit preset_item_categories_path(preset)
+            within ".category" do
+              fill_in 'item_category_item_category_name', with: category.item_category_name
+              click_button '作成'
+            end
+            expect(current_path).to eq preset_item_categories_path(preset)
+            expect(page).to have_content 'カテゴリーの作成に失敗しました'
+          end
+        end
+      end
+      context 'カテゴリー編集' do
+        let!(:category) { create(:item_category, preset: preset) }
+        context 'フォームの入力値が正常' do
+          it 'カテゴリーの編集に成功する' do
+            visit preset_item_categories_path(preset)
+            within ".category#{category.id}" do
+              fill_in 'item_category_item_category_name', with: 'update_category_name'
+              click_button '更新'
+            end
+            expect(current_path).to eq preset_item_categories_path(preset)
+            expect(page).to have_content "カテゴリー名をupdate_category_nameに更新しました"
+            visit preset_path(preset)
+            expect(page).to have_content 'update_category_name'
+            expect(page).not_to have_content '登録されたカテゴリーがありません'
+          end
+        end
+        context 'カテゴリー名が未入力' do
+          it 'カテゴリーの編集に失敗する' do
+            visit preset_item_categories_path(preset)
+            within ".category#{category.id}" do
+              fill_in 'item_category_item_category_name', with: ''
+              click_button '更新'
+            end
+            expect(current_path).to eq preset_item_categories_path(preset)
+            expect(page).to have_content "#{category.item_category_name}のカテゴリー名の変更に失敗しました"
+          end
+        end
+        context '既存のカテゴリー名と同じカテゴリー名が入力' do
+          let!(:another_category) { create(:item_category, preset: preset) }
+          it 'カテゴリーの編集に失敗する' do
+            visit preset_item_categories_path(preset)
+            within ".category#{category.id}" do
+              fill_in 'item_category_item_category_name', with: another_category.item_category_name
+              click_button '更新'
+            end
+            expect(current_path).to eq preset_item_categories_path(preset)
+            expect(page).to have_content "#{category.item_category_name}のカテゴリー名の変更に失敗しました"
+          end
+        end
+      end
+      context 'カテゴリー削除' do
+        let!(:category) { create(:item_category, preset: preset) }
+        context '削除するカテゴリーの削除をクリックする' do
+          it 'カテゴリーの削除に成功する' do
+            visit preset_item_categories_path(preset)
+            within ".category#{category.id}" do
+              click_on '削除'
+            end
+            expect(page.accept_confirm).to eq "カテゴリーを削除すると、そのカテゴリーの持ち物も削除されます。#{category.item_category_name}を削除してよろしいですか?"
+            expect(current_path).to eq preset_item_categories_path(preset)
+            expect(page).to have_content "#{category.item_category_name}を削除しました"
+            visit preset_path(preset)
+            expect(page).not_to have_content category.item_category_name
+            expect(page).to have_content '登録されたカテゴリーがありません'
+          end
+          context '削除するカテゴリーに持ち物が登録されている場合' do
+            let!(:item) { create(:preset_item, item_category: category) }
+            it '持ち物も削除される' do
+              visit preset_item_categories_path(preset)
+              within ".category#{category.id}" do
+                click_on '削除'
+              end
+              accept_confirm
+              visit preset_path(preset)
+              expect(page).not_to have_content item.preset_item_name
+              expect(PresetItem.find_by(id: item.id)).to be nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/preset_items_spec.rb
+++ b/spec/system/preset_items_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe 'PresetItems', type: :system do
+  describe 'プリセット用持ち物' do
+    let!(:user) { create(:user) }
+    let!(:preset) { create(:preset, user: user) }
+    before { login(user) }
+    context '持ち物追加' do
+      context 'カテゴリーが一つ以上登録済' do
+        let!(:category) { create(:item_category, preset: preset) }
+        before { visit new_preset_preset_item_path(preset) }
+        context 'フォームの入力値が正常' do
+          it '持ち物の作成に成功する' do
+            select category.item_category_name, from: 'preset_item_item_category_id'
+            fill_in 'preset_item_preset_item_name', with: 'item_name'
+            click_button '作成'
+            expect(current_path).to eq preset_path(preset)
+            within ".category#{category.id}" do
+              expect(page).to have_content 'item_name'
+              expect(page).not_to have_content 'このカテゴリーに登録された持ち物はありません'
+            end
+            expect(page).to have_content "item_nameを#{category.item_category_name}に追加しました"
+          end
+        end
+        context '持ち物名が未入力' do
+          it '持ち物の作成に失敗する' do
+            select category.item_category_name, from: 'preset_item_item_category_id'
+            fill_in 'preset_item_preset_item_name', with: ''
+            click_button '作成'
+            expect(page).to have_content '持ち物の作成に失敗しました'
+          end
+        end
+      end
+      context 'カテゴリーが未登録の場合' do
+        it 'プリセット詳細ページに飛ばされる' do
+          visit preset_path(preset)
+          expect(page).to have_content '登録されたカテゴリーがありません'
+          visit new_preset_preset_item_path(preset)
+          expect(current_path).to eq preset_item_categories_path(preset)
+          expect(page).to have_content '持ち物の追加を行う場合、先にカテゴリーを1つ以上登録をしてください'
+        end
+      end
+    end
+    context '持ち物編集' do
+      let!(:category) { create(:item_category, preset: preset) }
+      let!(:another_category) { create(:item_category, preset: preset) }
+      let!(:item) { create(:preset_item, item_category: category) }
+      before { visit edit_preset_preset_item_path(preset, item) }
+      context 'フォームの入力値が正常' do
+        it '持ち物の編集に成功する' do
+          select another_category.item_category_name, from: 'preset_item_item_category_id'
+          fill_in 'preset_item_preset_item_name', with: 'update_item_name'
+          click_button '更新'
+          expect(current_path).to eq preset_path(preset)
+          within ".category#{another_category.id}" do
+            expect(page).to have_content 'update_item_name'
+            expect(page).not_to have_content 'このカテゴリーに登録された持ち物はありません'
+          end
+          within ".category#{category.id}" do
+            expect(page).not_to have_content 'update_item_name'
+            expect(page).to have_content 'このカテゴリーに登録された持ち物はありません'
+          end
+          expect(page).to have_content 'update_item_nameの情報を更新しました'
+        end
+      end
+      context '持ち物名が未入力' do
+        it '持ち物の編集に失敗する' do
+          select another_category.item_category_name, from: 'preset_item_item_category_id'
+          fill_in 'preset_item_preset_item_name', with: ''
+          click_button '更新'
+          expect(current_path).to eq preset_preset_item_path(preset, item)
+          expect(page).to have_content "#{item.preset_item_name}の情報の更新に失敗しました"
+          expect(page).to have_content '持ち物名を入力してください'
+        end
+      end
+    end
+    context '持ち物削除' do
+      let!(:category) { create(:item_category, preset: preset) }
+      let!(:item) { create(:preset_item, item_category: category) }
+      context 'プリセット詳細ページ' do
+        it '持ち物の削除に成功する' do
+          visit preset_path(preset)
+          within ".item#{item.id}" do
+            click_on '削除'
+          end
+          expect(page.accept_confirm).to eq "#{item.preset_item_name}を削除してよろしいですか?"
+          expect(current_path).to eq preset_path(preset)
+          expect(page).to have_content "#{item.preset_item_name}を削除しました"
+          within ".category#{category.id}" do
+            expect(page).not_to have_content item.preset_item_name
+            expect(page).to have_content 'このカテゴリーに登録された持ち物はありません'
+          end
+        end
+      end
+      context '持ち物編集ページ' do
+        it '持ち物の削除に成功する' do
+          visit edit_preset_preset_item_path(preset, item)
+          click_on '削除'
+          expect(page.accept_confirm).to eq "#{item.preset_item_name}を削除してよろしいですか?"
+          expect(current_path).to eq preset_path(preset)
+          expect(page).to have_content "#{item.preset_item_name}を削除しました"
+          within ".category#{category.id}" do
+            expect(page).not_to have_content item.preset_item_name
+            expect(page).to have_content 'このカテゴリーに登録された持ち物はありません'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/presets_spec.rb
+++ b/spec/system/presets_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+RSpec.describe 'Presets', type: :system do
+  describe 'プリセット' do
+    let!(:user) { create(:user) }
+    before { login(user) }
+    context 'プリセット作成' do
+      before { visit new_preset_path }
+      context 'フォームの入力値が正常' do
+        it 'プリセットの作成に成功する' do
+          fill_in 'preset_preset_name', with: 'preset_1'
+          click_button '作成'
+          expect(current_path).to eq preset_path(Preset.find_by(preset_name: 'preset_1'))
+          expect(page).to have_content 'preset_1'
+          expect(page).to have_content 'preset_1を作成しました'
+        end
+      end
+      context 'プリセット名が未入力' do
+        it 'プリセットの作成に失敗する' do
+          fill_in 'preset_preset_name', with: ''
+          click_button '作成'
+          expect(page).to have_content 'プリセットの作成に失敗しました'
+          expect(page).to have_content 'プリセット名を入力してください'
+        end
+      end
+    end
+    context 'プリセット一覧' do
+      context '検索機能' do
+        context '存在するプリセット名を入力する' do
+          it '検索したプリセットが表示される' do
+            presets = create_list(:preset, 5, user: user)
+            visit presets_path
+            preset = presets[0]
+            another_preset = presets[1]
+            fill_in 'q_preset_name_cont', with: preset.preset_name
+            click_button '検索'
+            expect(current_path).to eq presets_path
+            expect(page).to have_content preset.preset_name
+            expect(page).not_to have_content another_preset.preset_name
+          end
+        end
+        context '存在しないプリセット名を入力する' do
+          it 'プリセットが表示されない' do
+            presets = create_list(:preset, 5, user: user)
+            visit presets_path
+            preset = presets[0]
+            fill_in 'q_preset_name_cont', with: 'name_miss_preset'
+            click_button '検索'
+            expect(current_path).to eq presets_path
+            expect(page).not_to have_content preset.preset_name
+          end
+        end
+      end
+      context 'ページネーション機能' do
+        context 'プリセットが16件以上' do
+          it 'ページネーションが表示され、正しく画面遷移する' do
+            presets = create_list(:preset, 20, user: user)
+            visit presets_path
+            expect(page).to have_css '.page-item'
+            expect(page).not_to have_content presets[15].preset_name
+            click_on '次 ›'
+            expect(page).to have_content presets[15].preset_name
+          end
+        end
+        context 'プリセットが15件以下' do
+          it 'ページネーションが表示されない' do
+            presets = create_list(:preset, 15, user: user)
+            visit presets_path
+            expect(page).not_to have_css '.page-item'
+          end
+        end
+      end
+    end
+    context 'プリセット名編集' do
+      let!(:preset) { create(:preset, user: user) }
+      before { visit edit_preset_path(preset) }
+      context 'フォームの入力値が正常' do
+        it 'プリセット名の編集に成功する' do
+          fill_in 'preset_preset_name', with: 'update_preset'
+          click_button '更新'
+          expect(current_path).to eq preset_path(preset)
+          expect(page).to have_content 'update_preset'
+          expect(page).to have_content 'プリセット名をupdate_presetに変更しました'
+        end
+      end
+      context 'プリセット名が未入力' do
+        it 'プリセット名の編集に失敗する' do
+          fill_in 'preset_preset_name', with: ''
+          click_button '更新'
+          expect(current_path).to eq preset_path(preset)
+          expect(page).to have_content 'プリセット名の変更に失敗しました'
+          expect(page).to have_content 'プリセット名を入力してください'
+        end
+      end
+    end
+    context 'プリセット削除' do
+      let!(:preset) { create(:preset, user: user) }
+      context 'プリセット一覧ページ' do
+        it '削除をクリックするとプリセットが削除される' do
+          visit presets_path
+          click_on '削除'
+          expect(page.accept_confirm).to eq "#{preset.preset_name}を削除してよろしいですか?"
+          expect(current_path).to eq presets_path
+          expect(page).to have_content "#{preset.preset_name}を削除しました"
+          expect(page).not_to have_link '詳細'
+        end
+      end
+      context 'プリセット詳細ページ' do
+        it 'プリセットの削除をクリックするとプリセットが削除される' do
+          visit preset_path(preset)
+          click_on 'プリセット削除'
+          expect(page.accept_confirm).to eq "#{preset.preset_name}を削除してよろしいですか?"
+          expect(current_path).to eq presets_path
+          expect(page).to have_content "#{preset.preset_name}を削除しました"
+          expect(page).not_to have_link '詳細'
+        end
+      end
+    end
+  end
+end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Profiles', type: :system do
       end
     end
     context 'パスワード変更ページ' do
-      before { visit new_profile_path }
+      before { visit password_reset_profile_path }
       context 'パスワード変更用メールの送信' do
         it 'パスワード変更用メールの送信がされる' do
           expect(page).to have_content user.email

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'UserSessions', type: :system do
       context 'パスワードが未入力' do
         it 'ログインに失敗する' do
           fill_in 'email', with: user.email
+          sleep(1)
           click_button 'ログイン'
           expect(current_path).to eq login_path
           expect(page).to have_content 'ログインに失敗しました'


### PR DESCRIPTION
## 概要

プリセットの作成、編集、削除、プリセットで使用するカテゴリーの作成、編集、削除、持ち物の登録、編集、削除機能を追加しました。また、プリセット一覧ページでは検索機能とページネーションを実装しました。

## 確認方法

1. カラムを追加したので `bundle exec rails db:migrate` を実行してください
2. プリセットの作成、編集、削除が行えることを確認してください。また、一覧ページでプリセットの検索が可能なこと、16件以上でページネーションが表示されることを確認ください。
3. プリセットで使用するカテゴリーの作成、編集、削除が行えることを確認ください。また、プリセットを削除した場合、それに含まれるカテゴリーも削除されることを確認ください。
4. プリセットで使用する持ち物の作成、編集、削除が行えることを確認ください。また、カテゴリーを削除した場合、それに含まれる持ち物も削除されることを確認ください。

## チェックリスト

プロジェクトごとにパスしなければならないルールを定義しておきましょう。例えば以下のように。

- [x] rspecをパスした

## コメント

rspecのことになりますが、`bundle exec rspec`で実行した場合になぜか`user_sessions_spec.rb`でエラーが発生しました。ファイル指定で`user_sessions_spec.rb`のみテストを行った場合は問題なくパスしたため、暫定処理としてエラー箇所に`sleep(1)`を加えてテストをパスさせました。