### PR TITLE
Create inventory list function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ group :test do
   gem 'faker'
   gem 'webdrivers'
   gem 'database_cleaner'
+  gem 'rspec-retry', '~> 0.4.6'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,6 +333,8 @@ GEM
       rspec-expectations (~> 3.11)
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
+    rspec-retry (0.4.6)
+      rspec-core
     rspec-support (3.12.0)
     rubocop (1.47.0)
       json (~> 2.3)
@@ -476,6 +478,7 @@ DEPENDENCIES
   ransack
   rename
   rspec-rails
+  rspec-retry (~> 0.4.6)
   rubocop
   rubocop-checkstyle_formatter
   rubocop-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,8 @@ class ApplicationController < ActionController::Base
   def preset_record_not_found
     redirect_to presets_path, alert: t('defaults.record_not_found')
   end
+
+  def inventory_list_record_not_found
+    redirect_to inventory_lists_path, alert: t('defaults.record_not_found')
+  end
 end

--- a/app/controllers/inventory_lists_controller.rb
+++ b/app/controllers/inventory_lists_controller.rb
@@ -1,0 +1,59 @@
+class InventoryListsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :inventory_list_record_not_found
+
+  def index
+    @q = current_user.inventory_lists.ransack(params[:q])
+    @inventory_lists = @q.result.order(:created_at).page(params[:page])
+  end
+
+  def new
+    @inventory_list = InventoryList.new
+  end
+
+  def create
+    @inventory_list = current_user.inventory_lists.new(list_params)
+    if @inventory_list.save
+      redirect_to inventory_list_path(@inventory_list), notice: t('.success', name: @inventory_list.inventory_list_name)
+    else
+      flash.now[:alert] = t('.fail')
+      render :new
+    end
+  end
+
+  def show
+    @inventory_list = current_user.inventory_lists.find(params[:id])
+    @property_categories = @inventory_list.property_categories.includes(:properties).order(:created_at)
+  end
+
+  def edit
+    @inventory_list = current_user.inventory_lists.find(params[:id])
+  end
+
+  def update
+    @inventory_list = current_user.inventory_lists.find(params[:id])
+    if @inventory_list.update(list_params)
+      redirect_to inventory_list_path(@inventory_list), notice: t('.success', name: @inventory_list.inventory_list_name)
+    else
+      flash.now[:alert] = t('.fail')
+      render :edit
+    end
+  end
+
+  def destroy
+    @inventory_list = current_user.inventory_lists.find(params[:id])
+    name = @inventory_list.inventory_list_name
+    @inventory_list.destroy!
+    redirect_to inventory_lists_path, notice: t('.success', name: name)
+  end
+
+  def use
+    @inventory_list = current_user.inventory_lists.find(params[:id])
+    @property_categories = @inventory_list.property_categories.includes(:properties).order(:created_at)
+  end
+
+  private
+
+  def list_params
+    params.require(:inventory_list).permit(:inventory_list_name)
+  end
+end

--- a/app/controllers/item_categories_controller.rb
+++ b/app/controllers/item_categories_controller.rb
@@ -1,6 +1,6 @@
 class ItemCategoriesController < ApplicationController
-  before_action :set_preset
   rescue_from ActiveRecord::RecordNotFound, with: :preset_record_not_found
+  before_action :set_preset
 
   def index
     @item_categories = @preset.item_categories.all.order(:created_at)

--- a/app/controllers/preset_items_controller.rb
+++ b/app/controllers/preset_items_controller.rb
@@ -1,6 +1,6 @@
 class PresetItemsController < ApplicationController
-  before_action :set_preset
   rescue_from ActiveRecord::RecordNotFound, with: :preset_record_not_found
+  before_action :set_preset
 
   def new
     redirect_to preset_item_categories_path(@preset), alert: t('.category_less_alert') unless @preset.item_categories.present?

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -1,0 +1,50 @@
+class PropertiesController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :inventory_list_record_not_found
+  before_action :set_inventory_list
+
+  def new
+    redirect_to inventory_list_property_categories_path(@inventory_list), alert: t('.category_less_alert') unless @inventory_list.property_categories.present?
+    @property = Property.new
+  end
+
+  def create
+    @property = Property.new(property_params)
+    if @property.save
+      redirect_to inventory_list_path(@inventory_list), notice: t('.success', property_name: @property.property_name, category_name: @property.property_category.category_name)
+    else
+      flash.now[:alert] = t('.fail')
+      render :new
+    end
+  end
+
+  def edit
+    @property = Property.find(params[:id])
+  end
+
+  def update
+    @property = Property.find(params[:id])
+    if @property.update(property_params)
+      redirect_to inventory_list_path(@inventory_list), notice: t('.success', name: @property.property_name)
+    else
+      flash.now[:alert] = t('.fail', name: Property.find(@property.id).property_name)
+      render :edit
+    end
+  end
+
+  def destroy
+    @property = Property.find(params[:id])
+    name = @property.property_name
+    @property.destroy!
+    redirect_to inventory_list_path(@inventory_list), notice: t('.success', name: name)
+  end
+
+  private
+
+  def set_inventory_list
+    @inventory_list = current_user.inventory_lists.find(params[:inventory_list_id])
+  end
+
+  def property_params
+    params.require(:property).permit(:property_category_id, :property_name)
+  end
+end

--- a/app/controllers/property_categories_controller.rb
+++ b/app/controllers/property_categories_controller.rb
@@ -1,0 +1,44 @@
+class PropertyCategoriesController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :inventory_list_record_not_found
+  before_action :set_inventory_list
+
+  def index
+    @property_categories = @inventory_list.property_categories.all.order(:created_at)
+    @property_category = @inventory_list.property_categories.new
+  end
+
+  def create
+    @property_category = @inventory_list.property_categories.new(category_params)
+    if @property_category.save
+      redirect_to inventory_list_property_categories_path(@inventory_list), notice: t('.success', name: @property_category.category_name)
+    else
+      redirect_to inventory_list_property_categories_path(@inventory_list), alert: t('.fail')
+    end
+  end
+
+  def update
+    @property_category = @inventory_list.property_categories.find(params[:id])
+    if @property_category.update(category_params)
+      redirect_to inventory_list_property_categories_path(@inventory_list), notice: t('.success', name: @property_category.category_name)
+    else
+      redirect_to inventory_list_property_categories_path(@inventory_list), alert: t('.fail', name:  PropertyCategory.find(@property_category.id).category_name)
+    end
+  end
+
+  def destroy
+    @property_category = @inventory_list.property_categories.find(params[:id])
+    name = @property_category.category_name
+    @property_category.destroy!
+    redirect_to inventory_list_property_categories_path(@inventory_list), notice: t('.success', name: name)
+  end
+
+  private
+
+  def set_inventory_list
+    @inventory_list = current_user.inventory_lists.find(params[:inventory_list_id])
+  end
+  
+  def category_params
+    params.require(:property_category).permit(:category_name)
+  end
+end

--- a/app/controllers/use_presets_controller.rb
+++ b/app/controllers/use_presets_controller.rb
@@ -1,0 +1,42 @@
+class UsePresetsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :inventory_list_record_not_found
+  before_action :set_inventory_list
+  
+  def index
+    @q = current_user.presets.ransack(params[:q])
+    @presets = @q.result.order(:created_at).page(params[:page])
+  end
+
+  def show
+    @preset = current_user.presets.find(params[:id])
+    @item_categories = @preset.item_categories.includes(:preset_items).order(:created_at)
+    @property_categories = @inventory_list.property_categories.includes(:properties).order(:created_at)
+  end
+
+  def update
+    @preset = current_user.presets.find(params[:id])
+    @item_categories = @preset.item_categories.includes(:preset_items).order(:created_at)
+    if @item_categories.present?
+      ActiveRecord::Base.transaction do
+        @item_categories.each do |item_category|
+          property_category = @inventory_list.property_categories.find_category(item_category.item_category_name)
+          property_category = @inventory_list.property_categories.create!(category_name: item_category.item_category_name) if property_category.nil?
+          if item_category.preset_items.present?
+            item_category.preset_items.each do |preset_item|
+              property_category.properties.create!(property_name: preset_item.preset_item_name)
+            end
+          end
+        end
+      end
+      redirect_to inventory_list_path(@inventory_list), notice: t('.success', preset_name: @preset.preset_name)
+    else
+      redirect_to inventory_list_use_preset_path(@inventory_list, @preset), alert: t('.preset_category_less')
+    end
+  end
+
+  private
+
+  def set_inventory_list
+    @inventory_list = current_user.inventory_lists.find(params[:inventory_list_id])
+  end
+end

--- a/app/helpers/properties_helper.rb
+++ b/app/helpers/properties_helper.rb
@@ -1,0 +1,5 @@
+module PropertiesHelper
+  def property_exists?(property)
+    Property.exists?(id: property.id)
+  end
+end

--- a/app/helpers/property_categories_helper.rb
+++ b/app/helpers/property_categories_helper.rb
@@ -1,0 +1,5 @@
+module PropertyCategoriesHelper
+  def property_category_exists?(property_category)
+    PropertyCategory.exists?(id: property_category.id)
+  end
+end

--- a/app/javascript/packs/inventory_list_use.js
+++ b/app/javascript/packs/inventory_list_use.js
@@ -1,0 +1,33 @@
+window.onload = function(){
+  let checkboxs = document.getElementsByName('check');
+  document.getElementById('checked_hide_true').onclick = function(){
+    let rbtncheck = document.getElementById('checked_hide_true');
+    if(rbtncheck.checked){
+      for(let i = 0; i < checkboxs.length; i++){
+        if(checkboxs[i].checked){
+          document.getElementsByClassName(checkboxs[i].value)[0].style.display = 'none';
+        }
+      }
+    }
+  }
+  document.getElementById('checked_hide_false').onclick = function(){
+    let rbtncheck = document.getElementById('checked_hide_false');
+    if(rbtncheck.checked){
+      for(let i = 0; i < checkboxs.length; i++){
+        document.getElementsByClassName(checkboxs[i].value)[0].style.display = 'block';
+      }
+    }
+  }
+  for(let n = 0; n < checkboxs.length; n++){
+    document.getElementsByName('check')[n].onclick = function(){
+      let rbtncheck = document.getElementById('checked_hide_true');
+      if(rbtncheck.checked){
+        for(let i = 0; i < checkboxs.length; i++){
+          if(checkboxs[i].checked){
+            document.getElementsByClassName(checkboxs[i].value)[0].style.display = 'none';
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/models/inventory_list.rb
+++ b/app/models/inventory_list.rb
@@ -1,0 +1,12 @@
+class InventoryList < ApplicationRecord
+  belongs_to :user
+  has_many :property_categories, dependent: :destroy
+
+  validates :inventory_list_name, presence: true
+
+  private
+
+  def self.ransackable_attributes(auth_object = nil)
+    ['inventory_list_name']
+  end
+end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,0 +1,5 @@
+class Property < ApplicationRecord
+  belongs_to :property_category
+
+  validates :property_name, presence: true
+end

--- a/app/models/property_category.rb
+++ b/app/models/property_category.rb
@@ -1,0 +1,10 @@
+class PropertyCategory < ApplicationRecord
+  belongs_to :inventory_list
+  has_many :properties, dependent: :destroy
+
+  validates :category_name, presence: true, uniqueness: { scope: :inventory_list_id }
+
+  def self.find_category(name)
+    find_by(category_name: name)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   
   has_many :presets
+  has_many :inventory_lists
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/inventory_lists/_list_name_form.html.erb
+++ b/app/views/inventory_lists/_list_name_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_with model: inventory_list, local: true do |f| %>
+  <%= render 'shared/error_messages', model: inventory_list %>
+  <div class = 'field'>
+    <%= f.label :inventory_list_name %><br />
+    <%= f.text_field :inventory_list_name %>
+  </div>
+  <div class = 'actions'>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/inventory_lists/_search.html.erb
+++ b/app/views/inventory_lists/_search.html.erb
@@ -1,0 +1,4 @@
+<%= search_form_for @q, url: url do |f| %>
+  <%= f.search_field :inventory_list_name_cont, class: 'form-control', placeholder: true %>
+  <%= f.submit t('defaults.search'), class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/inventory_lists/edit.html.erb
+++ b/app/views/inventory_lists/edit.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'list_name_form', inventory_list: @inventory_list %>

--- a/app/views/inventory_lists/index.html.erb
+++ b/app/views/inventory_lists/index.html.erb
@@ -1,0 +1,19 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'search', q: @q, url: inventory_lists_path %>
+
+<%= link_to t('inventory_lists.new.title'), new_inventory_list_path %>
+<br>
+<br>
+
+<% if @inventory_lists.present? %>
+  <% @inventory_lists.each do |inventory_list| %>
+    <%= inventory_list.inventory_list_name %>
+    <%= link_to t('defaults.show'), inventory_list_path(inventory_list) %>
+    <%= link_to t('defaults.destroy'), inventory_list_path(inventory_list), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: inventory_list.inventory_list_name)} %>
+    <br>
+  <% end %>
+  <%= paginate @inventory_lists %>
+<% else %>
+  <p><%= t '.list_less' %></p>
+<% end %>

--- a/app/views/inventory_lists/new.html.erb
+++ b/app/views/inventory_lists/new.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'list_name_form', inventory_list: @inventory_list %>

--- a/app/views/inventory_lists/show.html.erb
+++ b/app/views/inventory_lists/show.html.erb
@@ -1,0 +1,37 @@
+<h1><%= t('.title') %></h1>
+
+<%= @inventory_list.inventory_list_name %>
+<%= link_to t('.use_list'), use_inventory_list_path(@inventory_list), data: {'turbolinks' => false} %>
+<%= link_to t('inventory_lists.edit.title'), edit_inventory_list_path(@inventory_list) %>
+<%= link_to t('.list_destroy'), inventory_list_path(@inventory_list), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: @inventory_list.inventory_list_name)} %>
+<br>
+<br>
+<%= link_to t('.category_index'), inventory_list_property_categories_path(@inventory_list) %>
+<%= link_to t('.property_new'), new_inventory_list_property_path(@inventory_list) %>
+<%= link_to t('.use_preset'), inventory_list_use_presets_path(@inventory_list) %>
+<br>
+<br>
+<% if @property_categories.present? %>
+  <% @property_categories.each do |property_category| %>
+    <div class = "category<%= property_category.id %>">
+      <%= property_category.category_name %>
+      <br>
+      <br>
+      <% if property_category.properties.present? %>
+        <% property_category.properties.each do |property| %>
+          <div class = "property<%= property.id %>">
+            <%= property.property_name %>
+            <%= link_to t('defaults.edit'), edit_inventory_list_property_path(@inventory_list, property) %>
+            <%= link_to t('defaults.destroy'), inventory_list_property_path(@inventory_list, property), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: property.property_name)} %>
+            <br>
+            <br>
+          </div>
+        <% end %>
+      <% else %>
+        <p><%= t '.property_less' %></p>
+      <% end %>
+    </div>
+  <% end %>
+<% else %>
+  <p><%= t '.category_less' %></p>
+<% end %>

--- a/app/views/inventory_lists/use.html.erb
+++ b/app/views/inventory_lists/use.html.erb
@@ -1,0 +1,38 @@
+<h1><%= t('.title') %></h1>
+
+<%= javascript_pack_tag 'inventory_list_use' %>
+
+<%= form_with do |f| %>
+  <%= f.label :checked_hide, t('.not_checked_hide'), value: false, name: 'not_hide_rbtn' %>
+  <%= f.radio_button :checked_hide, 'false', { checked: true } %>
+  <br>
+  <%= f.label :checked_hide, t('.checked_hide'), value: true, name: 'hide_rbtn' %>
+  <%= f.radio_button :checked_hide, 'true' %>
+<% end %>
+<br>
+
+<%= @inventory_list.inventory_list_name %>
+<br>
+<br>
+<% if @property_categories.present? %>
+  <% @property_categories.each do |property_category| %>
+    <div class = "category<%= property_category.id %>">
+      <%= label_tag 'property_category[category_name]', property_category.category_name %>
+      <% if property_category.properties.present? %>
+        <% property_category.properties.each do |property| %>
+          <div class = "property property<%= property.id %>">
+            <%= label_tag 'property[property_name]' do %>
+              <%= check_box_tag :check, "property#{property.id}" %>
+              <%= property.property_name %>
+            <% end %>
+            <br>
+          </div>
+        <% end %>
+      <% else %>
+        <p><%= t '.property_less' %></p>
+      <% end %>
+    </div>
+  <% end %>
+<% else %>
+  <p><%= t '.category_less' %></p>
+<% end %>

--- a/app/views/item_categories/_preset_category_form.html.erb
+++ b/app/views/item_categories/_preset_category_form.html.erb
@@ -1,14 +1,14 @@
 <%= form_with model: [preset, item_category], local: true do |f| %>
   <div class = "category<%= item_category.id %>">
-  <div class = 'field'>
-    <%= f.text_field :item_category_name %>
-  </div>
-  <div class = 'actions'>
-    <%= f.submit %>
-    <% if item_category_exists?(item_category) %>
-      <%= link_to t('defaults.destroy'), preset_item_category_path(preset, item_category), method: :delete, data: {confirm: t('defaults.category_destroy_confirm', name: item_category.item_category_name)} %>
-    <% end %>
-  </div>
-  <br>
+    <div class = 'field'>
+      <%= f.text_field :item_category_name %>
+    </div>
+    <div class = 'actions'>
+      <%= f.submit %>
+      <% if item_category_exists?(item_category) %>
+        <%= link_to t('defaults.destroy'), preset_item_category_path(preset, item_category), method: :delete, data: {confirm: t('defaults.category_destroy_confirm', name: item_category.item_category_name)} %>
+      <% end %>
+    </div>
+    <br>
   </div>
 <% end %>

--- a/app/views/item_categories/index.html.erb
+++ b/app/views/item_categories/index.html.erb
@@ -6,3 +6,5 @@
 <% end %>
 
 <%= render 'preset_category_form', { item_category: @item_category, preset: @preset } %>
+
+<%= link_to t('presets.show.item_new'), new_preset_preset_item_path(@preset) %>

--- a/app/views/preset_items/edit.html.erb
+++ b/app/views/preset_items/edit.html.erb
@@ -1,3 +1,5 @@
 <h1><%= t '.title' %></h1>
 
 <%= render 'preset_item_form', { preset: @preset, preset_item: @preset_item } %>
+
+<%= link_to t('presets.show.category_index'), preset_item_categories_path(@preset) %>

--- a/app/views/preset_items/new.html.erb
+++ b/app/views/preset_items/new.html.erb
@@ -1,3 +1,5 @@
 <h1><%= t '.title' %></h1>
 
 <%= render 'preset_item_form', { preset: @preset, preset_item: @preset_item } %>
+
+<%= link_to t('presets.show.category_index'), preset_item_categories_path(@preset) %>

--- a/app/views/properties/_property_form.html.erb
+++ b/app/views/properties/_property_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with model: [inventory_list, property], local: true do |f| %>
+  <%= render 'shared/error_messages', model: property %>
+  <div class = 'field'>
+    <%= f.label PropertyCategory.human_attribute_name(:category_name) %><br />
+    <%= f.collection_select :property_category_id, inventory_list.property_categories, :id, :category_name %>
+  </div>
+  <div class = 'field'>
+    <%= f.label :property_name %><br />
+    <%= f.text_field :property_name %>
+  </div>
+  <div class = 'actions'>
+    <%= f.submit %>
+    <% if property_exists?(property) %>
+      <%= link_to t('defaults.destroy'), inventory_list_property_path(inventory_list, property), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: property.property_name)} %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/properties/edit.html.erb
+++ b/app/views/properties/edit.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'property_form', { inventory_list: @inventory_list, property: @property } %>
+
+<%= link_to t('inventory_lists.show.category_index'), inventory_list_property_categories_path(@inventory_list) %>

--- a/app/views/properties/new.html.erb
+++ b/app/views/properties/new.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'property_form', { inventory_list: @inventory_list, property: @property } %>
+
+<%= link_to t('inventory_lists.show.category_index'), inventory_list_property_categories_path(@inventory_list) %>

--- a/app/views/property_categories/_property_category_form.html.erb
+++ b/app/views/property_categories/_property_category_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_with model: [inventory_list, property_category], local: true do |f| %>
+  <div class = "category<%= property_category.id %>">
+    <div class = 'field'>
+      <%= f.text_field :category_name %>
+    </div>
+    <div class = 'actions'>
+      <%= f.submit %>
+      <% if property_category_exists?(property_category) %>
+        <%= link_to t('defaults.destroy'), inventory_list_property_category_path(inventory_list, property_category), method: :delete, data: {confirm: t('defaults.category_destroy_confirm', name: property_category.category_name)} %>
+      <% end %>
+    </div>
+    <br>
+  </div>
+<% end %>

--- a/app/views/property_categories/index.html.erb
+++ b/app/views/property_categories/index.html.erb
@@ -1,0 +1,10 @@
+<h1><%= t('.title') %></h1>
+
+<p><%= PropertyCategory.human_attribute_name(:category_name) %></p>
+<% if @property_categories.present? %>
+  <%= render partial: 'property_category_form', collection: @property_categories, as: 'property_category', locals: { inventory_list: @inventory_list } %>
+<% end %>
+
+<%= render 'property_category_form', { property_category: @property_category, inventory_list: @inventory_list } %>
+
+<%= link_to t('inventory_lists.show.property_new'), new_inventory_list_property_path(@inventory_list) %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,6 +1,6 @@
 <div>
   <%= link_to t('defaults.preset'), presets_path %>
-  <%= link_to t('defaults.inventory_list'), '#' %>
+  <%= link_to t('defaults.inventory_list'), inventory_lists_path %>
   <%= link_to t('defaults.purchase_list'), '#' %>
   <%= link_to t('defaults.schedule'), '#' %>
 </div>

--- a/app/views/use_presets/_search.html.erb
+++ b/app/views/use_presets/_search.html.erb
@@ -1,0 +1,4 @@
+<%= search_form_for @q, url: url do |f| %>
+  <%= f.search_field :preset_name_cont, class: 'form-control', placeholder: true %>
+  <%= f.submit t('defaults.search'), class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/use_presets/index.html.erb
+++ b/app/views/use_presets/index.html.erb
@@ -1,0 +1,18 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'search', q: @q, url: inventory_list_use_presets_path(@inventory_list) %>
+
+<%= link_to t('presets.new.title'), new_preset_path %>
+<br>
+<br>
+
+<% if @presets.present? %>
+  <% @presets.each do |preset| %>
+    <%= preset.preset_name %>
+    <%= link_to t('defaults.use'), inventory_list_use_preset_path(@inventory_list, preset) %>
+    <br>
+  <% end %>
+  <%= paginate @presets %>
+<% else %>
+  <p><%= t '.preset_less' %></p>
+<% end %>

--- a/app/views/use_presets/show.html.erb
+++ b/app/views/use_presets/show.html.erb
@@ -1,0 +1,61 @@
+<h1><%= t('.title') %></h1>
+
+<%= @preset.preset_name %>
+<br>
+<br>
+<%= link_to t('.edit_preset'), preset_path(@preset) %>
+<%= link_to t('.use_preset'), inventory_list_use_preset_path(@inventory_list, @preset),
+                              method: :patch,
+                              data: {confirm: t('.use_preset_confirm', inventory_list_name: @inventory_list.inventory_list_name, preset_name: @preset.preset_name)} %>
+<br>
+<br>
+<% if @item_categories.present? %>
+  <% @item_categories.each do |item_category| %>
+    <div class = "category<%= item_category.id %>">
+      <%= item_category.item_category_name %>
+      <br>
+      <br>
+      <% if item_category.preset_items.present? %>
+        <% item_category.preset_items.each do |preset_item| %>
+          <div class = "item<%= preset_item.id %>">
+            <%= preset_item.preset_item_name %>
+            <br>
+            <br>
+          </div>
+        <% end %>
+      <% else %>
+        <p><%= t '.item_less' %></p>
+      <% end %>
+    </div>
+  <% end %>
+<% else %>
+  <p><%= t '.category_less' %></p>
+<% end %>
+
+<br>
+<br>
+<%= @inventory_list.inventory_list_name %>
+<br>
+<br>
+<% if @property_categories.present? %>
+  <% @property_categories.each do |property_category| %>
+    <div class = "category<%= property_category.id %>">
+      <%= property_category.category_name %>
+      <br>
+      <br>
+      <% if property_category.properties.present? %>
+        <% property_category.properties.each do |property| %>
+          <div class = "property<%= property.id %>">
+            <%= property.property_name %>
+            <br>
+            <br>
+          </div>
+        <% end %>
+      <% else %>
+        <p><%= t '.property_less' %></p>
+      <% end %>
+    </div>
+  <% end %>
+<% else %>
+  <p><%= t '.category_less' %></p>
+<% end %>

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -5,6 +5,9 @@ ja:
       preset: 'プリセット'
       item_category: 'カテゴリー'
       preset_item: '持ち物'
+      inventory_list: '持ち物リスト'
+      property_category: 'カテゴリー'
+      property: '持ち物'
     attributes:
       user:
         id: 'ユーザーID'
@@ -21,6 +24,15 @@ ja:
       preset_item:
         id: 'プリセットアイテムID'
         preset_item_name: '持ち物名'
+      inventory_list:
+        id: '持ち物リストID'
+        inventory_list_name: '持ち物リスト名'
+      property_category:
+        id: 'カテゴリーID'
+        category_name: 'カテゴリー名'
+      property:
+        id: '持ち物ID'
+        property_name: '持ち物名'
   attributes:
     created_at: '作成日'
     updates_at: '更新日'

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -7,6 +7,7 @@ ja:
     show: '詳細'
     edit: '編集'
     destroy: '削除'
+    use: '使用'
     destroy_confirm: "%{name}を削除してよろしいですか?"
     category_destroy_confirm: "カテゴリーを削除すると、そのカテゴリーの持ち物も削除されます。%{name}を削除してよろしいですか?"
     register: '登録'
@@ -25,6 +26,7 @@ ja:
     placeholder:
       q:
         preset_name_cont: '検索ワード'
+        inventory_list_name_cont: '検索ワード'
   users:
     new:
       title: 'ユーザー登録'
@@ -99,6 +101,77 @@ ja:
       fail: "%{name}の情報の更新に失敗しました"
     destroy:
       success: "%{name}を削除しました"
+  inventory_lists:
+    index:
+      title: '持ち物リスト一覧'
+      list_less: '持ち物リストがありません'
+    new:
+      title: '持ち物リスト作成'
+    create:
+      success: "%{name}を作成しました"
+      fail: '持ち物リストの作成に失敗しました'
+    show:
+      title: '持ち物リスト詳細'
+      use_list: 'リスト使用'
+      list_destroy: '持ち物リスト削除'
+      category_index: 'カテゴリーの追加・編集・削除'
+      property_new: '持ち物の追加'
+      use_preset: 'プリセット使用'
+      category_less: '登録されたカテゴリーがありません'
+      property_less: 'このカテゴリーに登録された持ち物はありません'
+    edit:
+      title: '持ち物リスト名編集'
+    update:
+      success: "持ち物リスト名を%{name}に変更しました"
+      fail: '持ち物リスト名の変更に失敗しました'
+    destroy:
+      success: "%{name}を削除しました"
+    use:
+      title: '持ち物リスト使用'
+      checked_hide: 'チェックした持ち物を隠す'
+      not_checked_hide: 'チェックした持ち物を隠さない'
+      category_less: '登録されたカテゴリーがありません'
+      property_less: 'このカテゴリーに登録された持ち物はありません'
+  property_categories:
+    index:
+      title: 'カテゴリー編集'
+    create:
+      success: "%{name}を作成しました"
+      fail: 'カテゴリーの作成に失敗しました'
+    update:
+      success: "カテゴリー名を%{name}に更新しました"
+      fail: "%{name}のカテゴリー名の変更に失敗しました"
+    destroy:
+      success: "%{name}を削除しました"
+  properties:
+    new:
+      title: '持ち物追加'
+      category_less_alert: '持ち物の追加を行う場合、先にカテゴリーを1つ以上登録をしてください'
+    create:
+      success: "%{property_name}を%{category_name}に追加しました"
+      fail: '持ち物の作成に失敗しました'
+    edit:
+      title: '持ち物編集'
+    update:
+      success: "%{name}の情報を更新しました"
+      fail: "%{name}の情報の更新に失敗しました"
+    destroy:
+      success: "%{name}を削除しました"
+  use_presets:
+    index:
+      title: 'プリセット使用一覧'
+      preset_less: 'プリセットがありません'
+    show:
+      title: 'プリセットの内容確認'
+      edit_preset: 'プリセットの編集へ'
+      use_preset: 'このプリセットを使用する'
+      use_preset_confirm: "%{inventory_list_name}に%{preset_name}を適用してよろしいですか?"
+      category_less: '登録されたカテゴリーがありません'
+      item_less: 'このカテゴリーに登録された持ち物はありません'
+      property_less: 'このカテゴリーに登録された持ち物はありません'
+    update:
+      success: "%{preset_name}を反映しました"
+      preset_category_less: '使用しようとしたプリセットにカテゴリーが登録されていません'
   profiles:
     show:
       title: 'プロフィール'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,4 +18,10 @@ Rails.application.routes.draw do
     resources :item_categories, only: %i[index create update destroy]
     resources :preset_items, only: %i[new create edit update destroy]
   end
+  resources :inventory_lists do
+    get 'use', on: :member
+    resources :property_categories, only: %i[index create update destroy]
+    resources :properties, only: %i[new create edit update destroy]
+    resources :use_presets, only: %i[index show update]
+  end
 end

--- a/db/migrate/20230322110412_create_inventory_lists.rb
+++ b/db/migrate/20230322110412_create_inventory_lists.rb
@@ -1,0 +1,10 @@
+class CreateInventoryLists < ActiveRecord::Migration[6.1]
+  def change
+    create_table :inventory_lists do |t|
+      t.string :inventory_list_name, null: false
+      t.belongs_to :user, index: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230322110635_create_property_categories.rb
+++ b/db/migrate/20230322110635_create_property_categories.rb
@@ -1,0 +1,11 @@
+class CreatePropertyCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :property_categories do |t|
+      t.string :category_name, null: false
+      t.belongs_to :inventory_list, index: true, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :property_categories, [:category_name, :inventory_list_id], unique: true
+  end
+end

--- a/db/migrate/20230322110717_create_properties.rb
+++ b/db/migrate/20230322110717_create_properties.rb
@@ -1,0 +1,10 @@
+class CreateProperties < ActiveRecord::Migration[6.1]
+  def change
+    create_table :properties do |t|
+      t.string :property_name, null: false
+      t.belongs_to :property_category, index: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_13_112238) do
+ActiveRecord::Schema.define(version: 2023_03_22_110717) do
+
+  create_table "inventory_lists", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "inventory_list_name", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_inventory_lists_on_user_id"
+  end
 
   create_table "item_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "item_category_name", null: false
@@ -37,6 +45,23 @@ ActiveRecord::Schema.define(version: 2023_03_13_112238) do
     t.index ["user_id"], name: "index_presets_on_user_id"
   end
 
+  create_table "properties", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "property_name", null: false
+    t.bigint "property_category_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["property_category_id"], name: "index_properties_on_property_category_id"
+  end
+
+  create_table "property_categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "category_name", null: false
+    t.bigint "inventory_list_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_name", "inventory_list_id"], name: "index_property_categories_on_category_name_and_inventory_list_id", unique: true
+    t.index ["inventory_list_id"], name: "index_property_categories_on_inventory_list_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "user_name", null: false
     t.string "email", null: false
@@ -52,7 +77,10 @@ ActiveRecord::Schema.define(version: 2023_03_13_112238) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
+  add_foreign_key "inventory_lists", "users"
   add_foreign_key "item_categories", "presets"
   add_foreign_key "preset_items", "item_categories"
   add_foreign_key "presets", "users"
+  add_foreign_key "properties", "property_categories"
+  add_foreign_key "property_categories", "inventory_lists"
 end

--- a/spec/factories/inventory_lists.rb
+++ b/spec/factories/inventory_lists.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :inventory_list do
+    sequence(:inventory_list_name) { |n| "持ち物リスト#{n}" }
+    association :user
+  end
+end

--- a/spec/factories/properties.rb
+++ b/spec/factories/properties.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :property do
+    sequence(:property_name) { |n| "持ち物#{n}" }
+    association :property_category
+  end
+end

--- a/spec/factories/property_categories.rb
+++ b/spec/factories/property_categories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :property_category do
+    sequence(:category_name) { |n| "カテゴリー#{n}" }
+    association :inventory_list
+  end
+end

--- a/spec/models/inventory_list_spec.rb
+++ b/spec/models/inventory_list_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe InventoryList, type: :model do
+  describe 'のバリデーションが' do
+    it 'すべてのアトリビュートに適用されない' do
+      inventory_list = build(:inventory_list)
+      expect(inventory_list).to be_valid
+      expect(inventory_list.errors).to be_empty
+    end
+    it '持ち物リスト名がない場合に適用される' do
+      name_less_inventory_list = build(:inventory_list, inventory_list_name: '')
+      expect(name_less_inventory_list).not_to be_valid
+      expect(name_less_inventory_list.errors).not_to be_empty
+    end
+  end
+end

--- a/spec/models/item_category_spec.rb
+++ b/spec/models/item_category_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe ItemCategory, type: :model do
     it '別プリセット内に存在し、同一プリセット内には存在しないカテゴリー名の場合に適用されない' do
       item_category = create(:item_category)
       another_item_category = build(:item_category, item_category_name: item_category.item_category_name)
-      expect(item_category).to be_valid
-      expect(item_category.errors).to be_empty
+      expect(another_item_category).to be_valid
+      expect(another_item_category.errors).to be_empty
     end
   end
 end

--- a/spec/models/property_category_spec.rb
+++ b/spec/models/property_category_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe PropertyCategory, type: :model do
+  describe 'のバリデーションが' do
+    it 'すべてのアトリビュートに適用されない' do
+      property_category = build(:property_category)
+      expect(property_category).to be_valid
+      expect(property_category.errors).to be_empty
+    end
+    it 'カテゴリー名がない場合に適用される' do
+      name_less_property_category = build(:property_category, category_name: '')
+      expect(name_less_property_category).not_to be_valid
+      expect(name_less_property_category.errors).not_to be_empty
+    end
+    it '同一持ち物リスト内に存在するカテゴリー名の場合に適用される' do
+      inventory_list = create(:inventory_list)
+      property_category = create(:property_category, inventory_list: inventory_list)
+      another_property_category = build(:property_category, category_name: property_category.category_name, inventory_list: inventory_list)
+      expect(another_property_category).not_to be_valid
+      expect(another_property_category.errors).not_to be_empty
+    end
+    it '別持ち物リスト内に存在し、同一持ち物リスト内には存在しないカテゴリー名の場合に適用されない' do
+      property_category = create(:property_category)
+      another_property_category = build(:property_category, category_name: property_category.category_name)
+      expect(another_property_category).to be_valid
+      expect(another_property_category.errors).to be_empty
+    end
+  end
+end

--- a/spec/models/property_spec.rb
+++ b/spec/models/property_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Property, type: :model do
+  describe 'のバリデーションが' do
+    it 'すべてのアトリビュートに適用されない' do
+      property = build(:property)
+      expect(property).to be_valid
+      expect(property.errors).to be_empty
+    end
+    it '持ち物名がない場合に適用される' do
+      name_less_property = build(:property, property_name: '')
+      expect(name_less_property).not_to be_valid
+      expect(name_less_property.errors).not_to be_empty
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'rspec/retry'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -73,6 +74,15 @@ RSpec.configure do |config|
   end
   config.after(:all) do
     DatabaseCleaner.clean
+  end
+
+  # 実行中にリトライのステータスを表示する
+  config.verbose_retry = true
+  # リトライの原因となった例外を表示する
+  config.display_try_failure_messages = true
+
+  config.around do |ex|
+    ex.run_with_retry retry: 3, retry_wait: 1
   end
 
   config.include FactoryBot::Syntax::Methods

--- a/spec/system/inventory_lists_spec.rb
+++ b/spec/system/inventory_lists_spec.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+
+RSpec.describe 'InventoryLists', type: :system do
+  describe '持ち物リスト' do
+    let!(:user) { create(:user) }
+    before { login(user) }
+    context '持ち物リスト作成' do
+      before { visit new_inventory_list_path }
+      context 'フォームの入力値が正常' do
+        it '持ち物リストの作成に成功する' do
+          fill_in 'inventory_list_inventory_list_name', with: 'inventory_list_1'
+          click_button '作成'
+          expect(current_path).to eq inventory_list_path(InventoryList.find_by(inventory_list_name: 'inventory_list_1'))
+          expect(page).to have_content 'inventory_list_1'
+          expect(page).to have_content 'inventory_list_1を作成しました'
+        end
+      end
+      context '持ち物リスト名が未入力' do
+        it '持ち物リストの作成に失敗する' do
+          fill_in 'inventory_list_inventory_list_name', with: ''
+          click_button '作成'
+          expect(page).to have_content '持ち物リストの作成に失敗しました'
+          expect(page).to have_content '持ち物リスト名を入力してください'
+        end
+      end
+    end
+    context '持ち物リスト一覧' do
+      context '検索機能' do
+        context '存在する持ち物リスト名を入力する' do
+          it '検索した持ち物リストが表示される' do
+            inventory_lists = create_list(:inventory_list, 5, user: user)
+            visit inventory_lists_path
+            inventory_list = inventory_lists[0]
+            another_inventory_list = inventory_lists[1]
+            fill_in 'q_inventory_list_name_cont', with: inventory_list.inventory_list_name
+            click_button '検索'
+            expect(current_path).to eq inventory_lists_path
+            expect(page).to have_content inventory_list.inventory_list_name
+            expect(page).not_to have_content another_inventory_list.inventory_list_name
+          end
+        end
+        context '存在しない持ち物リスト名を入力する' do
+          it '持ち物リストが表示されない' do
+            inventory_lists = create_list(:inventory_list, 5, user: user)
+            visit inventory_lists_path
+            inventory_list = inventory_lists[0]
+            fill_in 'q_inventory_list_name_cont', with: 'name_miss_inventory_list'
+            click_button '検索'
+            expect(current_path).to eq inventory_lists_path
+            expect(page).not_to have_content inventory_list.inventory_list_name
+          end
+        end
+      end
+      context 'ページネーション機能' do
+        context '持ち物リストが16件以上' do
+          it 'ページネーションが表示され、正しく画面遷移する' do
+            inventory_lists = create_list(:inventory_list, 20, user: user)
+            visit inventory_lists_path
+            expect(page).to have_css '.page-item'
+            expect(page).not_to have_content inventory_lists[15].inventory_list_name
+            click_on '次 ›'
+            expect(page).to have_content inventory_lists[15].inventory_list_name
+          end
+        end
+        context '持ち物リストが15件以下' do
+          it 'ページネーションが表示されない' do
+            inventory_lists = create_list(:inventory_list, 15, user: user)
+            visit inventory_lists_path
+            expect(page).not_to have_css '.page-item'
+          end
+        end
+      end
+    end
+    context '持ち物リスト名編集' do
+      let!(:inventory_list) { create(:inventory_list, user: user) }
+      before { visit edit_inventory_list_path(inventory_list) }
+      context 'フォームの入力値が正常' do
+        it '持ち物リスト名の編集に成功する' do
+          fill_in 'inventory_list_inventory_list_name', with: 'update_inventory_list'
+          click_button '更新'
+          expect(current_path).to eq inventory_list_path(inventory_list)
+          expect(page).to have_content 'update_inventory_list'
+          expect(page).to have_content '持ち物リスト名をupdate_inventory_listに変更しました'
+        end
+      end
+      context '持ち物リスト名が未入力' do
+        it '持ち物リスト名の編集に失敗する' do
+          fill_in 'inventory_list_inventory_list_name', with: ''
+          click_button '更新'
+          expect(current_path).to eq inventory_list_path(inventory_list)
+          expect(page).to have_content '持ち物リスト名の変更に失敗しました'
+          expect(page).to have_content '持ち物リスト名を入力してください'
+        end
+      end
+    end
+    context '持ち物リスト削除' do
+      let!(:inventory_list) { create(:inventory_list, user: user) }
+      context '持ち物リスト一覧ページ' do
+        it '削除をクリックすると持ち物リストが削除される' do
+          visit inventory_lists_path
+          click_on '削除'
+          expect(page.accept_confirm).to eq "#{inventory_list.inventory_list_name}を削除してよろしいですか?"
+          expect(current_path).to eq inventory_lists_path
+          expect(page).to have_content "#{inventory_list.inventory_list_name}を削除しました"
+          expect(page).not_to have_link '詳細'
+        end
+      end
+      context '持ち物リスト詳細ページ' do
+        it '持ち物リスト削除をクリックすると持ち物リストが削除される' do
+          visit inventory_list_path(inventory_list)
+          click_on '持ち物リスト削除'
+          expect(page.accept_confirm).to eq "#{inventory_list.inventory_list_name}を削除してよろしいですか?"
+          expect(current_path).to eq inventory_lists_path
+          expect(page).to have_content "#{inventory_list.inventory_list_name}を削除しました"
+          expect(page).not_to have_link '詳細'
+        end
+      end
+    end
+    context '持ち物リスト使用' do
+      let!(:inventory_list) { create(:inventory_list, user: user) }
+      let!(:property_category) { create(:property_category, inventory_list: inventory_list) }
+      let!(:property) { create(:property, property_category: property_category) }
+      let!(:another_property) { create(:property, property_category: property_category) }
+      before { visit use_inventory_list_path(inventory_list) }
+      context '持ち物リスト使用ページ' do
+        context '「チェックした持ち物を隠さない」が選択されている' do
+          it '持ち物のチェックボタンをチェックしても持ち物が隠れない' do
+            choose 'チェックした持ち物を隠さない'
+            check property.property_name
+            uncheck another_property.property_name
+            expect(page).to have_content property.property_name
+            expect(page).to have_content another_property.property_name
+          end
+          it '持ち物のチェックボタンをチェックした後に「チェックした持ち物を隠す」を選択すると、チェックされた持ち物が隠れる' do
+            choose 'チェックした持ち物を隠さない'
+            check property.property_name
+            uncheck another_property.property_name
+            choose 'チェックした持ち物を隠す'
+            expect(page).not_to have_content property.property_name
+            expect(page).to have_content another_property.property_name
+          end
+        end
+        context '「チェックした持ち物を隠す」が選択されている' do
+          it '持ち物のチェックボタンをチェックしたら持ち物が隠れる' do
+            choose 'チェックした持ち物を隠す'
+            check property.property_name
+            uncheck another_property.property_name
+            expect(page).not_to have_content property.property_name
+            expect(page).to have_content another_property.property_name
+          end
+          it '持ち物のチェックボタンをチェックした後に「チェックした持ち物を隠さない」を選択すると、チェックされた持ち物が表示される' do
+            choose 'チェックした持ち物を隠す'
+            check property.property_name
+            uncheck another_property.property_name
+            choose 'チェックした持ち物を隠さない'
+            expect(page).to have_content property.property_name
+            expect(page).to have_content another_property.property_name
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/preset_items_spec.rb
+++ b/spec/system/preset_items_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'PresetItems', type: :system do
             fill_in 'preset_item_preset_item_name', with: ''
             click_button '作成'
             expect(page).to have_content '持ち物の作成に失敗しました'
+            expect(page).to have_content '持ち物名を入力してください'
           end
         end
       end

--- a/spec/system/properties_spec.rb
+++ b/spec/system/properties_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe 'Properties', type: :system do
+  describe '持ち物リスト用持ち物' do
+    let!(:user) { create(:user) }
+    let!(:inventory_list) { create(:inventory_list, user: user) }
+    before { login(user) }
+    context '持ち物追加' do
+      context 'カテゴリーが一つ以上登録済' do
+        let!(:category) { create(:property_category, inventory_list: inventory_list) }
+        before { visit new_inventory_list_property_path(inventory_list) }
+        context 'フォームの入力値が正常' do
+          it '持ち物の作成に成功する' do
+            select category.category_name, from: 'property_property_category_id'
+            fill_in 'property_property_name', with: 'property_name'
+            click_button '作成'
+            expect(current_path).to eq inventory_list_path(inventory_list)
+            within ".category#{category.id}" do
+              expect(page).to have_content 'property_name'
+              expect(page).not_to have_content 'このカテゴリーに登録された持ち物はありません'
+            end
+            expect(page).to have_content "property_nameを#{category.category_name}に追加しました"
+          end
+        end
+        context '持ち物名が未入力' do
+          it '持ち物の作成に失敗する' do
+            select category.category_name, from: 'property_property_category_id'
+            fill_in 'property_property_name', with: ''
+            click_button '作成'
+            expect(page).to have_content '持ち物の作成に失敗しました'
+            expect(page).to have_content '持ち物名を入力してください'
+          end
+        end
+      end
+      context 'カテゴリーが未登録の場合' do
+        it 'プリセット詳細ページに飛ばされる' do
+          visit inventory_list_path(inventory_list)
+          expect(page).to have_content '登録されたカテゴリーがありません'
+          visit new_inventory_list_property_path(inventory_list)
+          expect(current_path).to eq inventory_list_property_categories_path(inventory_list)
+          expect(page).to have_content '持ち物の追加を行う場合、先にカテゴリーを1つ以上登録をしてください'
+        end
+      end
+    end
+    context '持ち物編集' do
+      let!(:category) { create(:property_category, inventory_list: inventory_list) }
+      let!(:another_category) { create(:property_category, inventory_list: inventory_list) }
+      let!(:property) { create(:property, property_category: category) }
+      before { visit edit_inventory_list_property_path(inventory_list, property) }
+      context 'フォームの入力値が正常' do
+        it '持ち物の編集に成功する' do
+          select another_category.category_name, from: 'property_property_category_id'
+          fill_in 'property_property_name', with: 'update_property_name'
+          click_button '更新'
+          expect(current_path).to eq inventory_list_path(inventory_list)
+          within ".category#{another_category.id}" do
+            expect(page).to have_content 'update_property_name'
+            expect(page).not_to have_content 'このカテゴリーに登録された持ち物はありません'
+          end
+          within ".category#{category.id}" do
+            expect(page).not_to have_content 'update_property_name'
+            expect(page).to have_content 'このカテゴリーに登録された持ち物はありません'
+          end
+          expect(page).to have_content 'update_property_nameの情報を更新しました'
+        end
+      end
+      context '持ち物名が未入力' do
+        it '持ち物の編集に失敗する' do
+          select another_category.category_name, from: 'property_property_category_id'
+          fill_in 'property_property_name', with: ''
+          click_button '更新'
+          expect(current_path).to eq inventory_list_property_path(inventory_list, property)
+          expect(page).to have_content "#{property.property_name}の情報の更新に失敗しました"
+          expect(page).to have_content '持ち物名を入力してください'
+        end
+      end
+    end
+    context '持ち物削除' do
+      let!(:category) { create(:property_category, inventory_list: inventory_list) }
+      let!(:property) { create(:property, property_category: category) }
+      context 'プリセット詳細ページ' do
+        it '持ち物の削除に成功する' do
+          visit inventory_list_path(inventory_list)
+          within ".property#{property.id}" do
+            click_on '削除'
+          end
+          expect(page.accept_confirm).to eq "#{property.property_name}を削除してよろしいですか?"
+          expect(current_path).to eq inventory_list_path(inventory_list)
+          expect(page).to have_content "#{property.property_name}を削除しました"
+          within ".category#{category.id}" do
+            expect(page).not_to have_content property.property_name
+            expect(page).to have_content 'このカテゴリーに登録された持ち物はありません'
+          end
+        end
+      end
+      context '持ち物編集ページ' do
+        it '持ち物の削除に成功する' do
+          visit edit_inventory_list_property_path(inventory_list, property)
+          click_on '削除'
+          expect(page.accept_confirm).to eq "#{property.property_name}を削除してよろしいですか?"
+          expect(current_path).to eq inventory_list_path(inventory_list)
+          expect(page).to have_content "#{property.property_name}を削除しました"
+          within ".category#{category.id}" do
+            expect(page).not_to have_content property.property_name
+            expect(page).to have_content 'このカテゴリーに登録された持ち物はありません'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/property_categories_spec.rb
+++ b/spec/system/property_categories_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe 'ProeprtyCategories', type: :system do
+  describe '持ち物リスト用カテゴリー' do
+    let!(:user) { create(:user) }
+    let!(:inventory_list) { create(:inventory_list, user: user) }
+    before { login(user) }
+    context 'カテゴリー編集ページ' do
+      context 'カテゴリー作成' do
+        context 'フォームの入力値が正常' do
+          it 'カテゴリーの作成に成功する' do
+            visit inventory_list_property_categories_path(inventory_list)
+            fill_in 'property_category_category_name', with: 'category_1'
+            click_button '作成'
+            expect(current_path).to eq inventory_list_property_categories_path(inventory_list)
+            expect(page).to have_content 'category_1を作成しました'
+            visit inventory_list_path(inventory_list)
+            expect(page).to have_content 'category_1'
+            expect(page).not_to have_content '登録されたカテゴリーがありません'
+          end
+        end
+        context 'カテゴリー名が未入力' do
+          it 'カテゴリーの作成に失敗する' do
+            visit inventory_list_property_categories_path(inventory_list)
+            fill_in 'property_category_category_name', with: ''
+            click_button '作成'
+            expect(current_path).to eq inventory_list_property_categories_path(inventory_list)
+            expect(page).to have_content 'カテゴリーの作成に失敗しました'
+            visit inventory_list_path(inventory_list)
+            expect(page).to have_content '登録されたカテゴリーがありません'
+          end
+        end
+        context '既存のカテゴリー名と同じカテゴリー名が入力' do
+          let!(:category) { create(:property_category, inventory_list: inventory_list) }
+          it 'カテゴリーの作成に失敗する' do
+            visit inventory_list_property_categories_path(inventory_list)
+            within ".category" do
+              fill_in 'property_category_category_name', with: category.category_name
+              click_button '作成'
+            end
+            expect(current_path).to eq inventory_list_property_categories_path(inventory_list)
+            expect(page).to have_content 'カテゴリーの作成に失敗しました'
+          end
+        end
+      end
+      context 'カテゴリー編集' do
+        let!(:category) { create(:property_category, inventory_list: inventory_list) }
+        context 'フォームの入力値が正常' do
+          it 'カテゴリーの編集に成功する' do
+            visit inventory_list_property_categories_path(inventory_list)
+            within ".category#{category.id}" do
+              fill_in 'property_category_category_name', with: 'update_category_name'
+              click_button '更新'
+            end
+            expect(current_path).to eq inventory_list_property_categories_path(inventory_list)
+            expect(page).to have_content "カテゴリー名をupdate_category_nameに更新しました"
+            visit inventory_list_path(inventory_list)
+            expect(page).to have_content 'update_category_name'
+            expect(page).not_to have_content '登録されたカテゴリーがありません'
+          end
+        end
+        context 'カテゴリー名が未入力' do
+          it 'カテゴリーの編集に失敗する' do
+            visit inventory_list_property_categories_path(inventory_list)
+            within ".category#{category.id}" do
+              fill_in 'property_category_category_name', with: ''
+              click_button '更新'
+            end
+            expect(current_path).to eq inventory_list_property_categories_path(inventory_list)
+            expect(page).to have_content "#{category.category_name}のカテゴリー名の変更に失敗しました"
+          end
+        end
+        context '既存のカテゴリー名と同じカテゴリー名が入力' do
+          let!(:another_category) { create(:property_category, inventory_list: inventory_list) }
+          it 'カテゴリーの編集に失敗する' do
+            visit inventory_list_property_categories_path(inventory_list)
+            within ".category#{category.id}" do
+              fill_in 'property_category_category_name', with: another_category.category_name
+              click_button '更新'
+            end
+            expect(current_path).to eq inventory_list_property_categories_path(inventory_list)
+            expect(page).to have_content "#{category.category_name}のカテゴリー名の変更に失敗しました"
+          end
+        end
+      end
+      context 'カテゴリー削除' do
+        let!(:category) { create(:property_category, inventory_list: inventory_list) }
+        context '削除するカテゴリーの削除をクリックする' do
+          it 'カテゴリーの削除に成功する' do
+            visit inventory_list_property_categories_path(inventory_list)
+            within ".category#{category.id}" do
+              click_on '削除'
+            end
+            expect(page.accept_confirm).to eq "カテゴリーを削除すると、そのカテゴリーの持ち物も削除されます。#{category.category_name}を削除してよろしいですか?"
+            expect(current_path).to eq inventory_list_property_categories_path(inventory_list)
+            expect(page).to have_content "#{category.category_name}を削除しました"
+            visit inventory_list_path(inventory_list)
+            expect(page).not_to have_content category.category_name
+            expect(page).to have_content '登録されたカテゴリーがありません'
+          end
+          context '削除するカテゴリーに持ち物が登録されている場合' do
+            let!(:property) { create(:property, property_category: category) }
+            it '持ち物も削除される' do
+              visit inventory_list_property_categories_path(inventory_list)
+              within ".category#{category.id}" do
+                click_on '削除'
+              end
+              accept_confirm
+              visit inventory_list_path(inventory_list)
+              expect(page).not_to have_content property.property_name
+              expect(Property.find_by(id: property.id)).to be nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/use_presets_spec.rb
+++ b/spec/system/use_presets_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe 'UsePresets', type: :system do
+  describe '持ち物リストプリセット使用' do
+    let!(:user) { create(:user) }
+    let!(:preset) { create(:preset, user: user) }
+    let!(:inventory_list) { create(:inventory_list, user: user) }
+    before { login(user) }
+    context 'プリセット使用' do
+      context '使用するプリセットにカテゴリーが登録されている' do
+        let!(:preset_category) { create(:item_category, preset: preset) }
+        context '使用するプリセットと使用先の持ち物リストに同名のカテゴリーが存在する' do
+          let!(:item) { create(:preset_item, item_category: preset_category) }
+          let!(:property_category) { create(:property_category, category_name: preset_category.item_category_name, inventory_list: inventory_list) }
+          let!(:property) { create(:property, property_category: property_category) }
+          it '持ち物リストに同名のカテゴリーは追加されず、持ち物は持ち物リストのそのカテゴリーに登録される' do
+            visit inventory_list_use_preset_path(inventory_list, preset)
+            click_on 'このプリセットを使用する'
+            expect(page.accept_confirm).to eq "#{inventory_list.inventory_list_name}に#{preset.preset_name}を適用してよろしいですか?"
+            expect(current_path).to eq inventory_list_path(inventory_list)
+            within ".category#{property_category.id}" do
+              expect(page).to have_content property.property_name
+              expect(page).to have_content item.preset_item_name
+            end
+          end
+        end
+        context '使用するプリセットと使用先の持ち物リストに同名のカテゴリーが存在しない' do
+          let!(:item) { create(:preset_item, item_category: preset_category) }
+          let!(:property_category) { create(:property_category, inventory_list: inventory_list) }
+          let!(:property) { create(:property, property_category: property_category) }
+          it '持ち物リストにカテゴリーと持ち物が登録される' do
+            visit inventory_list_use_preset_path(inventory_list, preset)
+            click_on 'このプリセットを使用する'
+            expect(page.accept_confirm).to eq "#{inventory_list.inventory_list_name}に#{preset.preset_name}を適用してよろしいですか?"
+            expect(current_path).to eq inventory_list_path(inventory_list)
+            within ".category#{property_category.id}" do
+              expect(page).to have_content property_category.category_name
+              expect(page).to have_content property.property_name
+            end
+            preset_category_id = PropertyCategory.find_by(category_name: preset_category.item_category_name).id
+            within ".category#{preset_category_id}" do
+              expect(page).to have_content preset_category.item_category_name
+              expect(page).to have_content item.preset_item_name
+            end
+          end
+        end
+        context '使用するプリセットに持ち物が登録されていない' do
+          let!(:preset_category) { create(:item_category, preset: preset) }
+          it '持ち物リストにカテゴリーだけ登録される' do
+            visit inventory_list_use_preset_path(inventory_list, preset)
+            click_on 'このプリセットを使用する'
+            expect(page.accept_confirm).to eq "#{inventory_list.inventory_list_name}に#{preset.preset_name}を適用してよろしいですか?"
+            expect(current_path).to eq inventory_list_path(inventory_list)
+            preset_category_id = PropertyCategory.find_by(category_name: preset_category.item_category_name).id
+            within ".category#{preset_category_id}" do
+              expect(page).to have_content preset_category.item_category_name
+              expect(page).to have_content 'このカテゴリーに登録された持ち物はありません'
+            end
+          end
+        end
+      end
+      context '使用するプリセットにカテゴリーが登録されていない' do
+        it 'エラーメッセージと共にプリセット内容確認ページにリダイレクトする' do
+          visit inventory_list_use_preset_path(inventory_list, preset)
+          click_on 'このプリセットを使用する'
+          expect(page.accept_confirm).to eq "#{inventory_list.inventory_list_name}に#{preset.preset_name}を適用してよろしいですか?"
+          expect(current_path).to eq inventory_list_use_preset_path(inventory_list, preset)
+          expect(page).to have_content '使用しようとしたプリセットにカテゴリーが登録されていません'
+        end
+      end
+    end
+  end
+end

--- a/spec/system/use_presets_spec.rb
+++ b/spec/system/use_presets_spec.rb
@@ -69,5 +69,52 @@ RSpec.describe 'UsePresets', type: :system do
         end
       end
     end
+    context '使用プリセット選択' do
+      context '検索機能' do
+        context '存在するプリセット名を入力する' do
+          it '検索したプリセットが表示される' do
+            presets = create_list(:preset, 5, user: user)
+            visit inventory_list_use_presets_path(inventory_list)
+            preset = presets[0]
+            another_preset = presets[1]
+            fill_in 'q_preset_name_cont', with: preset.preset_name
+            click_button '検索'
+            expect(current_path).to eq inventory_list_use_presets_path(inventory_list)
+            expect(page).to have_content preset.preset_name
+            expect(page).not_to have_content another_preset.preset_name
+          end
+        end
+        context '存在しないプリセット名を入力する' do
+          it 'プリセットが表示されない' do
+            presets = create_list(:preset, 5, user: user)
+            visit inventory_list_use_presets_path(inventory_list)
+            preset = presets[0]
+            fill_in 'q_preset_name_cont', with: 'name_miss_preset'
+            click_button '検索'
+            expect(current_path).to eq inventory_list_use_presets_path(inventory_list)
+            expect(page).not_to have_content preset.preset_name
+          end
+        end
+      end
+      context 'ページネーション機能' do
+        context 'プリセットが16件以上' do
+          it 'ページネーションが表示され、正しく画面遷移する' do
+            presets = create_list(:preset, 20, user: user)
+            visit inventory_list_use_presets_path(inventory_list)
+            expect(page).to have_css '.page-item'
+            expect(page).not_to have_content presets[15].preset_name
+            click_on '次 ›'
+            expect(page).to have_content presets[15].preset_name
+          end
+        end
+        context 'プリセットが15件以下' do
+          it 'ページネーションが表示されない' do
+            presets = create_list(:preset, 14, user: user)
+            visit inventory_list_use_presets_path(inventory_list)
+            expect(page).not_to have_css '.page-item'
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/system/user_sessions_spec.rb
+++ b/spec/system/user_sessions_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe 'UserSessions', type: :system do
       context 'パスワードが未入力' do
         it 'ログインに失敗する' do
           fill_in 'email', with: user.email
-          sleep(1)
           click_button 'ログイン'
           expect(current_path).to eq login_path
           expect(page).to have_content 'ログインに失敗しました'


### PR DESCRIPTION
## 概要

持ち物リストの作成、編集、削除、カテゴリーの作成、編集、削除、持ち物の作成、編集、削除、持ち物リスト使用機能、プリセットの使用機能を実装しました。
また、持ち物リスト一覧ページ、使用するプリセット選択ページには検索機能とページネーションを実装しました。
また、rspecの実行結果が安定しなかったことからrspec-retryを導入しました。

## 確認方法

1. Gem を追加したので `bundle install` を実行してください
2. カラムを追加したので `bundle exec rails db:migrate` を実行してください
3. 持ち物リストの作成、編集、削除が行えることを確認してください。また、一覧ページでは持ち物リストの検索が可能なこと、16件以上でページネーションが表示されることを確認してください。
4. カテゴリーの作成、編集、削除が行えることを確認してください。また、持ち物リストを削除した際にそれに含まれるカテゴリーも削除されることを確認してください。
5. 持ち物の作成、編集、削除が行えることを確認してください。また、カテゴリーが削除された際にそれに含まれる持ち物も削除されることを確認してください。
6. 持ち物リストの使用ページではチェックリスト方式で持ち物リストの使用ができ、ラジオボタンの選択次第でチェックボタンの選択した持ち物が隠れることを確認してください。
7. プリセット使用では選択したプリセットのカテゴリー、および持ち物が持ち物リストに追加されることを確認してください。また、プリセットのカテゴリーが持ち物リストのカテゴリーと同名の場合にはそのカテゴリーに持ち物が追加されることを確認してください。なお、使用するプリセットにカテゴリーが登録されていない場合はエラーメッセージと共に使用プリセット確認ページにリダイレクトされることを確認してください。

## チェックリスト

- [x] rspecをパスした
