### PR TITLE
物販購入リスト機能実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,4 +14,8 @@ class ApplicationController < ActionController::Base
   def inventory_list_record_not_found
     redirect_to inventory_lists_path, alert: t('defaults.record_not_found')
   end
+
+  def purchase_list_record_not_found
+    redirect_to purchase_lists_path, alert: t('defaults.record_not_found')
+  end
 end

--- a/app/controllers/purchase_lists_controller.rb
+++ b/app/controllers/purchase_lists_controller.rb
@@ -1,0 +1,54 @@
+class PurchaseListsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :purchase_list_record_not_found
+
+  def index
+    @q = current_user.purchase_lists.ransack(params[:q])
+    @purchase_lists = @q.result.order(:created_at).page(params[:page])
+  end
+
+  def new
+    @purchase_list = PurchaseList.new
+  end
+
+  def create
+    @purchase_list = current_user.purchase_lists.new(list_params)
+    if @purchase_list.save
+      redirect_to purchase_list_path(@purchase_list), notice: t('.success', name: @purchase_list.purchase_list_name)
+    else
+      flash.now[alert] = t('.fail')
+      render :new
+    end
+  end
+
+  def show
+    @purchase_list = current_user.purchase_lists.find(params[:id])
+    @purchases = @purchase_list.purchases.all.order(:created_at)
+  end
+
+  def edit
+    @purchase_list = current_user.purchase_lists.find(params[:id])
+  end
+
+  def update
+    @purchase_list = current_user.purchase_lists.find(params[:id])
+    if @purchase_list.update(list_params)
+      redirect_to purchase_list_path(@purchase_list), notice: t('.success', name: @purchase_list.purchase_list_name)
+    else
+      flash.now[alert] = t('.fail')
+      render :edit
+    end
+  end
+
+  def destroy
+    @purchase_list = current_user.purchase_lists.find(params[:id])
+    name = @purchase_list.purchase_list_name
+    @purchase_list.destroy!
+    redirect_to purchase_lists_path, notice: t('.success', name: name)
+  end
+
+  private
+
+  def list_params
+    params.require(:purchase_list).permit(:purchase_list_name)
+  end
+end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,0 +1,49 @@
+class PurchasesController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :purchase_list_record_not_found
+  before_action :set_purchase_list
+
+  def new
+    @purchase = @purchase_list.purchases.new
+  end
+
+  def create
+    @purchase = @purchase_list.purchases.new(purchase_params)
+    if @purchase.save
+      redirect_to purchase_list_path(@purchase_list), notice: t('.success', name: @purchase.purchase_name)
+    else
+      flash.now[:alert] = t('.fail')
+      render :new
+    end
+  end
+
+  def edit
+    @purchase = @purchase_list.purchases.find(params[:id])
+  end
+
+  def update
+    @purchase = @purchase_list.purchases.find(params[:id])
+    if @purchase.update(purchase_params)
+      redirect_to purchase_list_path(@purchase_list), notice: t('.success', name: @purchase.purchase_name)
+    else
+      flash.now[:alert] = t('.fail', name: Purchase.find(@purchase.id).purchase_name)
+      render :new
+    end
+  end
+
+  def destroy
+    @purchase = @purchase_list.purchases.find(params[:id])
+    name = @purchase.purchase_name
+    @purchase.destroy!
+    redirect_to purchase_list_path(@purchase_list), notice: t('.success', name: name)
+  end
+
+  private
+
+  def set_purchase_list
+    @purchase_list = current_user.purchase_lists.find(params[:purchase_list_id])
+  end
+
+  def purchase_params
+    params.require(:purchase).permit(:purchase_name, :price, :quantity)
+  end
+end

--- a/app/decorators/purchase_decorator.rb
+++ b/app/decorators/purchase_decorator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module PurchaseDecorator
+  def amount
+    price * quantity
+  end
+end

--- a/app/helpers/item_categories_helper.rb
+++ b/app/helpers/item_categories_helper.rb
@@ -1,5 +1,0 @@
-module ItemCategoriesHelper
-  def item_category_exists?(item_category)
-    ItemCategory.exists?(id: item_category.id)
-  end
-end

--- a/app/helpers/preset_items_helper.rb
+++ b/app/helpers/preset_items_helper.rb
@@ -1,5 +1,0 @@
-module PresetItemsHelper
-  def preset_item__exists?(preset_item)
-    PresetItem.exists?(id: preset_item.id)
-  end
-end

--- a/app/helpers/properties_helper.rb
+++ b/app/helpers/properties_helper.rb
@@ -1,5 +1,0 @@
-module PropertiesHelper
-  def property_exists?(property)
-    Property.exists?(id: property.id)
-  end
-end

--- a/app/helpers/property_categories_helper.rb
+++ b/app/helpers/property_categories_helper.rb
@@ -1,5 +1,0 @@
-module PropertyCategoriesHelper
-  def property_category_exists?(property_category)
-    PropertyCategory.exists?(id: property_category.id)
-  end
-end

--- a/app/helpers/purchase_lists_helper.rb
+++ b/app/helpers/purchase_lists_helper.rb
@@ -1,0 +1,9 @@
+module PurchaseListsHelper
+  def sum_amount(purchases)
+    result = 0
+    purchases.each do |purchase|
+      result += purchase.amount
+    end
+    result.to_s(:delimited) + t('defaults.yen')
+  end
+end

--- a/app/models/item_category.rb
+++ b/app/models/item_category.rb
@@ -3,4 +3,8 @@ class ItemCategory < ApplicationRecord
   has_many :preset_items, dependent: :destroy
 
   validates :item_category_name, presence: true, uniqueness: { scope: :preset_id }
+
+  def edit?
+    ItemCategory.exists?(id: id)
+  end
 end

--- a/app/models/preset_item.rb
+++ b/app/models/preset_item.rb
@@ -2,4 +2,8 @@ class PresetItem < ApplicationRecord
   belongs_to :item_category
 
   validates :preset_item_name, presence: true
+  
+  def edit?
+    PresetItem.exists?(id: id)
+  end
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -2,4 +2,8 @@ class Property < ApplicationRecord
   belongs_to :property_category
 
   validates :property_name, presence: true
+
+  def edit?
+    Property.exists?(id: id)
+  end
 end

--- a/app/models/property_category.rb
+++ b/app/models/property_category.rb
@@ -7,4 +7,8 @@ class PropertyCategory < ApplicationRecord
   def self.find_category(name)
     find_by(category_name: name)
   end
+
+  def edit?
+    PropertyCategory.exists?(id: id)
+  end
 end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,0 +1,11 @@
+class Purchase < ApplicationRecord
+  belongs_to :purchase_list
+
+  validates :purchase_name, presence: true
+  validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :quantity, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+
+  def edit?
+    Purchase.exists?(id: id)
+  end
+end

--- a/app/models/purchase_list.rb
+++ b/app/models/purchase_list.rb
@@ -1,0 +1,12 @@
+class PurchaseList < ApplicationRecord
+  belongs_to :user
+  has_many :purchases, dependent: :destroy
+
+  validates :purchase_list_name, presence: true
+
+  private
+
+  def self.ransackable_attributes(auth_object = nil)
+    ['purchase_list_name']
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,9 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   
-  has_many :presets
-  has_many :inventory_lists
+  has_many :presets, dependent: :destroy
+  has_many :inventory_lists, dependent: :destroy
+  has_many :purchase_lists, dependent: :destroy
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/item_categories/_preset_category_form.html.erb
+++ b/app/views/item_categories/_preset_category_form.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class = 'actions'>
       <%= f.submit %>
-      <% if item_category_exists?(item_category) %>
+      <% if item_category.edit? %>
         <%= link_to t('defaults.destroy'), preset_item_category_path(preset, item_category), method: :delete, data: {confirm: t('defaults.category_destroy_confirm', name: item_category.item_category_name)} %>
       <% end %>
     </div>

--- a/app/views/preset_items/_preset_item_form.html.erb
+++ b/app/views/preset_items/_preset_item_form.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class = 'actions'>
     <%= f.submit %>
-    <% if preset_item__exists?(preset_item) %>
+    <% if preset_item.edit? %>
       <%= link_to t('defaults.destroy'), preset_preset_item_path(preset, preset_item), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: preset_item.preset_item_name)} %>
     <% end %>
   </div>

--- a/app/views/properties/_property_form.html.erb
+++ b/app/views/properties/_property_form.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class = 'actions'>
     <%= f.submit %>
-    <% if property_exists?(property) %>
+    <% if property.edit? %>
       <%= link_to t('defaults.destroy'), inventory_list_property_path(inventory_list, property), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: property.property_name)} %>
     <% end %>
   </div>

--- a/app/views/property_categories/_property_category_form.html.erb
+++ b/app/views/property_categories/_property_category_form.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class = 'actions'>
       <%= f.submit %>
-      <% if property_category_exists?(property_category) %>
+      <% if property_category.edit? %>
         <%= link_to t('defaults.destroy'), inventory_list_property_category_path(inventory_list, property_category), method: :delete, data: {confirm: t('defaults.category_destroy_confirm', name: property_category.category_name)} %>
       <% end %>
     </div>

--- a/app/views/purchase_lists/_list_name_form.html.erb
+++ b/app/views/purchase_lists/_list_name_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_with model: purchase_list, local: true do |f| %>
+  <%= render 'shared/error_messages', model: purchase_list %>
+  <div class = 'field'>
+    <%= f.label :purchase_list_name %><br />
+    <%= f.text_field :purchase_list_name %>
+  </div>
+  <div class = 'actions'>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/purchase_lists/_search.html.erb
+++ b/app/views/purchase_lists/_search.html.erb
@@ -1,0 +1,4 @@
+<%= search_form_for @q, url: url do |f| %>
+  <%= f.search_field :purchase_list_name_cont, class: 'form-control', placeholder: true %>
+  <%= f.submit t('defaults.search'), class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/purchase_lists/edit.html.erb
+++ b/app/views/purchase_lists/edit.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'list_name_form', purchase_list: @purchase_list %>

--- a/app/views/purchase_lists/index.html.erb
+++ b/app/views/purchase_lists/index.html.erb
@@ -1,0 +1,19 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'search', q: @q, url: purchase_lists_path %>
+
+<%= link_to t('purchase_lists.new.title'), new_purchase_list_path %>
+<br>
+<br>
+
+<% if @purchase_lists.present? %>
+  <% @purchase_lists.each do |purchase_list| %>
+    <%= purchase_list.purchase_list_name %>
+    <%= link_to t('defaults.show'), purchase_list_path(purchase_list) %>
+    <%= link_to t('defaults.destroy'), purchase_list_path(purchase_list), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: purchase_list.purchase_list_name)} %>
+    <br>
+  <% end %>
+  <%= paginate @purchase_lists %>
+<% else %>
+  <p><%= t '.list_less' %></p>
+<% end %>

--- a/app/views/purchase_lists/new.html.erb
+++ b/app/views/purchase_lists/new.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'list_name_form', purchase_list: @purchase_list %>

--- a/app/views/purchase_lists/show.html.erb
+++ b/app/views/purchase_lists/show.html.erb
@@ -1,0 +1,35 @@
+<h1><%= t('.title') %></h1>
+
+<%= @purchase_list.purchase_list_name %>
+<%= link_to t('purchase_lists.edit.title'), edit_purchase_list_path(@purchase_list) %>
+<%= link_to t('.list_destroy'), purchase_list_path(@purchase_list), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: @purchase_list.purchase_list_name)} %>
+<br>
+<br>
+<%= link_to t('.purchase_new'), new_purchase_list_purchase_path(@purchase_list) %>
+<br>
+<br>
+<% if @purchases.present? %>
+  <%= Purchase.human_attribute_name(:purchase_name) %>
+  <%= Purchase.human_attribute_name(:price) %>
+  <%= Purchase.human_attribute_name(:quantity) %>
+  <%= t('.amount') %>
+  <br>
+  <br>
+  <% @purchases.each do |purchase| %>
+    <div class = "purchase<%= purchase.id %>">
+      <%= purchase.purchase_name %>
+      <%= "#{purchase.price.to_s(:delimited)}#{t('defaults.yen')}" %>
+      <%= "#{purchase.quantity}#{t('defaults.quantity')}" %>
+      <%= "#{purchase.amount.to_s(:delimited)}#{t('defaults.yen')}" %>
+      <%= link_to t('defaults.edit'), edit_purchase_list_purchase_path(@purchase_list, purchase) %>
+      <%= link_to t('defaults.destroy'), purchase_list_purchase_path(@purchase_list, purchase), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: purchase.purchase_name)} %>
+    </div>
+  <% end %>
+  <br>
+  <%= t('.sum_amount') %>
+  <%= sum_amount(@purchases) %>
+  <br>
+  <br>
+<% else %>
+  <p><%= t '.purchase_less' %></p>
+<% end %>

--- a/app/views/purchases/_purchase_form.html.erb
+++ b/app/views/purchases/_purchase_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with model: [purchase_list, purchase], local: true do |f| %>
+  <%= render 'shared/error_messages', model: purchase %>
+  <div class = 'field'>
+    <%= f.label :purchase_name %><br />
+    <%= f.text_field :purchase_name %>
+  </div>
+  <div class = 'field'>
+    <%= f.label :price %><br />
+    <%= f.number_field :price, min: 0 %>
+  </div>
+  <div class = 'field'>
+    <%= f.label :quantity %><br />
+    <%= f.number_field :quantity, min: 1 %>
+  </div>
+  <div class = 'actions'>
+    <%= f.submit %>
+    <% if purchase.edit? %>
+      <%= link_to t('defaults.destroy'), purchase_list_purchase_path(purchase_list, purchase), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: purchase.purchase_name)} %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/purchases/edit.html.erb
+++ b/app/views/purchases/edit.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'purchase_form', { purchase_list: @purchase_list, purchase: @purchase } %>

--- a/app/views/purchases/new.html.erb
+++ b/app/views/purchases/new.html.erb
@@ -1,0 +1,3 @@
+<h1><%= t '.title' %></h1>
+
+<%= render 'purchase_form', { purchase_list: @purchase_list, purchase: @purchase } %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,6 +1,6 @@
 <div>
   <%= link_to t('defaults.preset'), presets_path %>
   <%= link_to t('defaults.inventory_list'), inventory_lists_path %>
-  <%= link_to t('defaults.purchase_list'), '#' %>
+  <%= link_to t('defaults.purchase_list'), purchase_lists_path %>
   <%= link_to t('defaults.schedule'), '#' %>
 </div>

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -33,6 +33,14 @@ ja:
       property:
         id: '持ち物ID'
         property_name: '持ち物名'
+      purchase_list:
+        id: '物販購入リストID'
+        purchase_list_name: '物販購入リスト名'
+      purchase:
+        id: '購入品ID'
+        purchase_name: '購入品名'
+        price: '値段'
+        quantity: '個数'
   attributes:
     created_at: '作成日'
     updates_at: '更新日'

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -15,6 +15,8 @@ ja:
     save: '保存'
     search: '検索'
     record_not_found: 'アクセスしたページは存在しません'
+    yen: '円'
+    quantity: '個'
     preset: 'プリセット'
     inventory_list: '持ち物リスト'
     purchase_list: '物販購入リスト'
@@ -27,6 +29,7 @@ ja:
       q:
         preset_name_cont: '検索ワード'
         inventory_list_name_cont: '検索ワード'
+        purchase_list_name_cont: '検索ワード'
   users:
     new:
       title: 'ユーザー登録'
@@ -172,6 +175,42 @@ ja:
     update:
       success: "%{preset_name}を反映しました"
       preset_category_less: '使用しようとしたプリセットにカテゴリーが登録されていません'
+  purchase_lists:
+    index:
+      title: '物販購入リスト'
+      list_less: '物販購入リストがありません'
+    new:
+      title: '物販購入リスト作成'
+    create:
+      success: "%{name}を作成しました"
+      fail: '物販購入リストの作成に失敗しました'
+    show:
+      title: '物販購入リスト詳細'
+      list_destroy: '物販購入リスト削除'
+      purchase_new: '購入品の追加'
+      amount: '金額'
+      sum_amount: '合計金額'
+      purchase_less: '購入品が登録されていません'
+    edit:
+      title: '物販購入リスト名編集'
+    update:
+      success: "物販購入リスト名を%{name}に変更しました"
+      fail: '物販購入リスト名の変更に失敗しました'
+    destroy:
+      success: "%{name}を削除しました"
+  purchases:
+    new:
+      title: '購入品追加'
+    create:
+      success: "%{name}を追加しました"
+      fail: '購入品の作成に失敗しました'
+    edit:
+      title: '購入品編集'
+    update:
+      success: "%{name}の情報を更新しました"
+      fail: "%{name}の情報の更新に失敗しました"
+    destroy:
+      success: "%{name}を削除しました"
   profiles:
     show:
       title: 'プロフィール'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,7 @@ Rails.application.routes.draw do
     resources :properties, only: %i[new create edit update destroy]
     resources :use_presets, only: %i[index show update]
   end
+  resources :purchase_lists do
+    resources :purchases, only: %i[new create edit update destroy]
+  end
 end

--- a/db/migrate/20230329082234_create_purchase_lists.rb
+++ b/db/migrate/20230329082234_create_purchase_lists.rb
@@ -1,0 +1,10 @@
+class CreatePurchaseLists < ActiveRecord::Migration[6.1]
+  def change
+    create_table :purchase_lists do |t|
+      t.string :purchase_list_name, null: false
+      t.belongs_to :user, index: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230329082457_create_purchases.rb
+++ b/db/migrate/20230329082457_create_purchases.rb
@@ -1,0 +1,12 @@
+class CreatePurchases < ActiveRecord::Migration[6.1]
+  def change
+    create_table :purchases do |t|
+      t.string :purchase_name, null: false
+      t.integer :price, null: false
+      t.integer :quantity, null: false
+      t.belongs_to :purchase_list, index: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_22_110717) do
+ActiveRecord::Schema.define(version: 2023_03_29_082457) do
 
   create_table "inventory_lists", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "inventory_list_name", null: false
@@ -62,6 +62,24 @@ ActiveRecord::Schema.define(version: 2023_03_22_110717) do
     t.index ["inventory_list_id"], name: "index_property_categories_on_inventory_list_id"
   end
 
+  create_table "purchase_lists", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "purchase_list_name", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_purchase_lists_on_user_id"
+  end
+
+  create_table "purchases", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "purchase_name", null: false
+    t.integer "price", null: false
+    t.integer "quantity", null: false
+    t.bigint "purchase_list_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["purchase_list_id"], name: "index_purchases_on_purchase_list_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "user_name", null: false
     t.string "email", null: false
@@ -83,4 +101,6 @@ ActiveRecord::Schema.define(version: 2023_03_22_110717) do
   add_foreign_key "presets", "users"
   add_foreign_key "properties", "property_categories"
   add_foreign_key "property_categories", "inventory_lists"
+  add_foreign_key "purchase_lists", "users"
+  add_foreign_key "purchases", "purchase_lists"
 end

--- a/spec/factories/purchase_lists.rb
+++ b/spec/factories/purchase_lists.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :purchase_list do
+    sequence(:purchase_list_name) { |n| "物販購入リスト#{n}" }
+    association :user
+  end
+end

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :purchase do
+    sequence(:purchase_name) { |n| "購入品#{n}" }
+    price { 1000 }
+    quantity { Faker::Number.between(from: 1, to: 10) }
+    association :purchase_list
+  end
+end

--- a/spec/models/purchase_list_spec.rb
+++ b/spec/models/purchase_list_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe PurchaseList, type: :model do
+  describe 'のバリデーションが' do
+    it 'すべてのアトリビュートに適用されない' do
+      purchase_list = build(:purchase_list)
+      expect(purchase_list).to be_valid
+      expect(purchase_list.errors).to be_empty
+    end
+    it '物販購入リスト名がない場合に適用される' do
+      name_less_purchase_list = build(:purchase_list, purchase_list_name: '')
+      expect(name_less_purchase_list).not_to be_valid
+      expect(name_less_purchase_list.errors).not_to be_empty
+    end
+  end
+end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Purchase, type: :model do
+  describe 'のバリデーションが' do
+    it 'すべてのアトリビュートに適用されない' do
+      purchase = build(:purchase)
+      expect(purchase).to be_valid
+      expect(purchase.errors).to be_empty
+    end
+    it '購入品名がない場合に適用される' do
+      name_less_purchase = build(:purchase, purchase_name: '')
+      expect(name_less_purchase).not_to be_valid
+      expect(name_less_purchase.errors).not_to be_empty
+    end
+    it '金額がない場合に適用される' do
+      price_less_purchase = build(:purchase, price: '')
+      expect(price_less_purchase).not_to be_valid
+      expect(price_less_purchase.errors).not_to be_empty
+    end
+    it '金額が0未満の場合に適用される' do
+      price_minus_purchase = build(:purchase, price: -1)
+      expect(price_minus_purchase).not_to be_valid
+      expect(price_minus_purchase.errors).not_to be_empty
+    end
+    it '個数がない場合に適用される' do
+      quantity_less_purchase = build(:purchase, quantity: '')
+      expect(quantity_less_purchase).not_to be_valid
+      expect(quantity_less_purchase.errors).not_to be_empty
+    end
+    it '個数が1未満の場合に適用される' do
+      quantity_0_purchase = build(:purchase, quantity: 0)
+      expect(quantity_0_purchase).not_to be_valid
+      expect(quantity_0_purchase.errors).not_to be_empty
+    end
+  end
+end

--- a/spec/system/inventory_lists_spec.rb
+++ b/spec/system/inventory_lists_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'InventoryLists', type: :system do
             click_button '検索'
             expect(current_path).to eq inventory_lists_path
             expect(page).not_to have_content inventory_list.inventory_list_name
+            expect(page).to have_content '持ち物リストがありません'
           end
         end
       end

--- a/spec/system/presets_spec.rb
+++ b/spec/system/presets_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'Presets', type: :system do
             click_button '検索'
             expect(current_path).to eq presets_path
             expect(page).not_to have_content preset.preset_name
+            expect(page).to have_content 'プリセットがありません'
           end
         end
       end

--- a/spec/system/properties_spec.rb
+++ b/spec/system/properties_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Properties', type: :system do
     context '持ち物削除' do
       let!(:category) { create(:property_category, inventory_list: inventory_list) }
       let!(:property) { create(:property, property_category: category) }
-      context 'プリセット詳細ページ' do
+      context '持ち物リスト詳細ページ' do
         it '持ち物の削除に成功する' do
           visit inventory_list_path(inventory_list)
           within ".property#{property.id}" do

--- a/spec/system/purchase_lists_spec.rb
+++ b/spec/system/purchase_lists_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+RSpec.describe 'PurchaseLists', type: :system do
+  describe '物販購入リスト' do
+    let!(:user) { create(:user) }
+    before { login(user) }
+    context '物販購入リスト作成' do
+      before { visit new_purchase_list_path }
+      context 'フォームの入力値が正常' do
+        it '物販購入リストの作成に成功する' do
+          fill_in 'purchase_list_purchase_list_name', with: 'purchase_list_1'
+          click_button '作成'
+          expect(current_path).to eq purchase_list_path(PurchaseList.find_by(purchase_list_name: 'purchase_list_1'))
+          expect(page).to have_content 'purchase_list_1'
+          expect(page).to have_content 'purchase_list_1を作成しました'
+        end
+      end
+      context '物販購入リスト名が未入力' do
+        it '物販購入リストの作成に失敗する' do
+          fill_in 'purchase_list_purchase_list_name', with: ''
+          click_button '作成'
+          expect(page).to have_content '物販購入リストの作成に失敗しました'
+          expect(page).to have_content '物販購入リスト名を入力してください'
+        end
+      end
+    end
+    context '物販購入リスト一覧' do
+      context '検索機能' do
+        context '存在する物販購入リスト名を入力する' do
+          it '検索した物販購入リストが表示される' do
+            purchase_lists = create_list(:purchase_list, 5, user: user)
+            visit purchase_lists_path
+            purchase_list = purchase_lists[0]
+            another_purchase_list = purchase_lists[1]
+            fill_in 'q_purchase_list_name_cont', with: purchase_list.purchase_list_name
+            click_button '検索'
+            expect(current_path).to eq purchase_lists_path
+            expect(page).to have_content purchase_list.purchase_list_name
+            expect(page).not_to have_content another_purchase_list.purchase_list_name
+          end
+        end
+        context '存在しない物販購入リスト名を入力する' do
+          it '物販購入リストが表示されない' do
+            purchase_lists = create_list(:purchase_list, 5, user: user)
+            visit purchase_lists_path
+            purchase_list = purchase_lists[0]
+            fill_in 'q_purchase_list_name_cont', with: 'name_miss_purchase_list'
+            click_button '検索'
+            expect(current_path).to eq purchase_lists_path
+            expect(page).not_to have_content purchase_list.purchase_list_name
+            expect(page).to have_content '物販購入リストがありません'
+          end
+        end
+      end
+      context 'ページネーション機能' do
+        context '物販購入リストが16件以上' do
+          it 'ページネーションが表示され、正しく画面遷移する' do
+            purchase_lists = create_list(:purchase_list, 20, user: user)
+            visit purchase_lists_path
+            expect(page).to have_css '.page-item'
+            expect(page).not_to have_content purchase_lists[15].purchase_list_name
+            click_on '次 ›'
+            expect(page).to have_content purchase_lists[15].purchase_list_name
+          end
+        end
+        context '物販購入リストが15件以下' do
+          it 'ページネーションが表示されない' do
+            purchase_lists = create_list(:purchase_list, 15, user: user)
+            visit purchase_lists_path
+            expect(page).not_to have_css '.page-item'
+          end
+        end
+      end
+    end
+    context '物販購入リスト名編集' do
+      let!(:purchase_list) { create(:purchase_list, user: user) }
+      before { visit edit_purchase_list_path(purchase_list) }
+      context 'フォームの入力値が正常' do
+        it '物販購入リスト名の編集に成功する' do
+          fill_in 'purchase_list_purchase_list_name', with: 'update_purchase_list'
+          click_button '更新'
+          expect(current_path).to eq purchase_list_path(purchase_list)
+          expect(page).to have_content 'update_purchase_list'
+          expect(page).to have_content '物販購入リスト名をupdate_purchase_listに変更しました'
+        end
+      end
+      context '物販購入リスト名が未入力' do
+        it '物販購入リスト名の編集に失敗する' do
+          fill_in 'purchase_list_purchase_list_name', with: ''
+          click_button '更新'
+          expect(current_path).to eq purchase_list_path(purchase_list)
+          expect(page).to have_content '物販購入リスト名の変更に失敗しました'
+          expect(page).to have_content '物販購入リスト名を入力してください'
+        end
+      end
+    end
+    context '物販購入リスト削除' do
+      let!(:purchase_list) { create(:purchase_list, user: user) }
+      context '物販購入リスト一覧ページ' do
+        it '削除をクリックすると物販購入リストが削除される' do
+          visit purchase_lists_path
+          click_on '削除'
+          expect(page.accept_confirm).to eq "#{purchase_list.purchase_list_name}を削除してよろしいですか?"
+          expect(current_path).to eq purchase_lists_path
+          expect(page).to have_content "#{purchase_list.purchase_list_name}を削除しました"
+          expect(page).not_to have_link '詳細'
+        end
+      end
+      context '物販購入リスト詳細ページ' do
+        it '物販購入リストの削除をクリックすると物販購入リストが削除される' do
+          visit purchase_list_path(purchase_list)
+          click_on '物販購入リスト削除'
+          expect(page.accept_confirm).to eq "#{purchase_list.purchase_list_name}を削除してよろしいですか?"
+          expect(current_path).to eq purchase_lists_path
+          expect(page).to have_content "#{purchase_list.purchase_list_name}を削除しました"
+          expect(page).not_to have_link '詳細'
+        end
+      end
+    end
+    context '物販購入リスト詳細' do
+      context '合計金額表示' do
+        let!(:purchase_list) { create(:purchase_list, user: user) }
+        let!(:purchase) { create(:purchase, purchase_list: purchase_list) }
+        let!(:another_purchase) { create(:purchase, purchase_list: purchase_list) }
+        it '購入品が一つ以上登録されている場合に合計金額が表示される' do
+          visit purchase_list_path(purchase_list)
+          expect(page).to have_content purchase.purchase_name
+          expect(page).to have_content another_purchase.purchase_name
+          result = (purchase.price * purchase.quantity) + (another_purchase.price * another_purchase.quantity)
+          expect(page).to have_content result.to_s(:delimited) + '円'
+        end
+      end
+    end
+  end
+end

--- a/spec/system/purchases_spec.rb
+++ b/spec/system/purchases_spec.rb
@@ -1,0 +1,179 @@
+require 'rails_helper'
+
+RSpec.describe 'Purchases', type: :system do
+  describe '物販購入リスト用購入品' do
+    let!(:user) { create(:user) }
+    let!(:purchase_list) { create(:purchase_list, user: user) }
+    before { login(user) }
+    context '購入品追加' do
+      before { visit new_purchase_list_purchase_path(purchase_list) }
+      context 'フォームの入力値が正常' do
+        it '購入品の作成に成功する' do
+          fill_in 'purchase_purchase_name', with: 'purchase_1'
+          fill_in 'purchase_price', with: 1000
+          fill_in 'purchase_quantity', with: 5
+          click_button '作成'
+          expect(current_path).to eq purchase_list_path(purchase_list)
+          within ".purchase#{Purchase.find_by(purchase_name: 'purchase_1').id}" do
+            expect(page).to have_content 'purchase_1'
+            expect(page).to have_content "1,000円"
+            expect(page).to have_content '5個'
+            expect(page).to have_content '5,000円'
+          end
+          expect(page).to have_content 'purchase_1を追加しました'
+        end
+      end
+      context '購入品名が未入力' do
+        it '購入品の作成に失敗する' do
+          fill_in 'purchase_purchase_name', with: ''
+          fill_in 'purchase_price', with: 1000
+          fill_in 'purchase_quantity', with: 5
+          click_button '作成'
+          expect(current_path).to eq purchase_list_purchases_path(purchase_list)
+          expect(page).to have_content '購入品の作成に失敗しました'
+          expect(page).to have_content '購入品名を入力してください'
+        end
+      end
+      context '値段が未入力' do
+        it '購入品の作成に失敗する' do
+          fill_in 'purchase_purchase_name', with: 'purchase_1'
+          fill_in 'purchase_price', with: ''
+          fill_in 'purchase_quantity', with: 5
+          click_button '作成'
+          expect(current_path).to eq purchase_list_purchases_path(purchase_list)
+          expect(page).to have_content '購入品の作成に失敗しました'
+          expect(page).to have_content '値段を入力してください'
+          expect(page).to have_content '値段は数値で入力してください'
+        end
+      end
+      context '値段が0未満' do
+        it '購入品の作成に失敗する' do
+          fill_in 'purchase_purchase_name', with: 'purchase_1'
+          fill_in 'purchase_price', with: -1
+          fill_in 'purchase_quantity', with: 5
+          click_button '作成'
+          expect(current_path).not_to eq purchase_list_path(purchase_list)
+        end
+      end
+      context '個数が未入力' do
+        it '購入品の作成に失敗する' do
+          fill_in 'purchase_purchase_name', with: 'purchase_1'
+          fill_in 'purchase_price', with: 1000
+          fill_in 'purchase_quantity', with: ''
+          click_button '作成'
+          expect(current_path).to eq purchase_list_purchases_path(purchase_list)
+          expect(page).to have_content '購入品の作成に失敗しました'
+          expect(page).to have_content '個数を入力してください'
+          expect(page).to have_content '個数は数値で入力してください'
+        end
+      end
+      context '個数が1未満' do
+        it '購入品の作成に失敗する' do
+          fill_in 'purchase_purchase_name', with: 'purchase_1'
+          fill_in 'purchase_price', with: 1000
+          fill_in 'purchase_quantity', with: 0
+          click_button '作成'
+          expect(current_path).not_to eq purchase_list_path(purchase_list)
+        end
+      end
+    end
+    context '購入品編集' do
+      let!(:purchase) { create(:purchase, purchase_list: purchase_list) }
+      before { visit edit_purchase_list_purchase_path(purchase_list, purchase) }
+      context 'フォームの入力値が正常' do
+        it '購入品の編集に成功する' do
+          fill_in 'purchase_purchase_name', with: 'update_purchase'
+          fill_in 'purchase_price', with: 1000
+          fill_in 'purchase_quantity', with: 5
+          click_button '更新'
+          expect(current_path).to eq purchase_list_path(purchase_list)
+          within ".purchase#{purchase.id}" do
+            expect(page).to have_content 'update_purchase'
+            expect(page).to have_content "1,000円"
+            expect(page).to have_content '5個'
+            expect(page).to have_content '5,000円'
+          end
+          expect(page).to have_content 'update_purchaseの情報を更新しました'
+        end
+      end
+      context '購入品名が未入力' do
+        it '購入品の編集に失敗する' do
+          fill_in 'purchase_purchase_name', with: ''
+          fill_in 'purchase_price', with: 1000
+          fill_in 'purchase_quantity', with: 5
+          click_button '更新'
+          expect(current_path).to eq purchase_list_purchase_path(purchase_list, purchase)
+          expect(page).to have_content "#{purchase.purchase_name}の情報の更新に失敗しました"
+          expect(page).to have_content '購入品名を入力してください'
+        end
+      end
+      context '値段が未入力' do
+        it '購入品の編集に失敗する' do
+          fill_in 'purchase_purchase_name', with: 'update_purchase'
+          fill_in 'purchase_price', with: ''
+          fill_in 'purchase_quantity', with: 5
+          click_button '更新'
+          expect(current_path).to eq purchase_list_purchase_path(purchase_list, purchase)
+          expect(page).to have_content "#{purchase.purchase_name}の情報の更新に失敗しました"
+          expect(page).to have_content '値段を入力してください'
+          expect(page).to have_content '値段は数値で入力してください'
+        end
+      end
+      context '値段が0未満' do
+        it '購入品の編集に失敗する' do
+          fill_in 'purchase_purchase_name', with: 'update_purchase'
+          fill_in 'purchase_price', with: -1
+          fill_in 'purchase_quantity', with: 5
+          click_button '更新'
+          expect(current_path).not_to eq purchase_list_path(purchase_list)
+        end
+      end
+      context '個数が未入力' do
+        it '購入品の編集に失敗する' do
+          fill_in 'purchase_purchase_name', with: 'update_purchase'
+          fill_in 'purchase_price', with: 1000
+          fill_in 'purchase_quantity', with: ''
+          click_button '更新'
+          expect(current_path).to eq purchase_list_purchase_path(purchase_list, purchase)
+          expect(page).to have_content "#{purchase.purchase_name}の情報の更新に失敗しました"
+          expect(page).to have_content '個数を入力してください'
+          expect(page).to have_content '個数は数値で入力してください'
+        end
+      end
+      context '個数が1未満' do
+        it '購入品の編集に失敗する' do
+          fill_in 'purchase_purchase_name', with: 'update_purchase'
+          fill_in 'purchase_price', with: 1000
+          fill_in 'purchase_quantity', with: 0
+          click_button '更新'
+          expect(current_path).not_to eq purchase_list_path(purchase_list)
+        end
+      end
+    end
+    context '購入品削除' do
+      let!(:purchase) { create(:purchase, purchase_list: purchase_list) }
+      context '物販購入リスト詳細ページ' do
+        it '購入品の削除に成功する' do
+          visit purchase_list_path(purchase_list)
+          within ".purchase#{purchase.id}" do
+            click_on '削除'
+          end
+          expect(page.accept_confirm).to eq "#{purchase.purchase_name}を削除してよろしいですか?"
+          expect(current_path).to eq purchase_list_path(purchase_list)
+          expect(page).to have_content "#{purchase.purchase_name}を削除しました"
+          expect(page).to have_content '購入品が登録されていません'
+        end
+      end
+      context '購入品編集ページ' do
+        it '購入品の削除に成功する' do
+          visit edit_purchase_list_purchase_path(purchase_list, purchase)
+          click_on '削除'
+          expect(page.accept_confirm).to eq "#{purchase.purchase_name}を削除してよろしいですか?"
+          expect(current_path).to eq purchase_list_path(purchase_list)
+          expect(page).to have_content "#{purchase.purchase_name}を削除しました"
+          expect(page).to have_content '購入品が登録されていません'
+        end
+      end
+    end
+  end
+end

--- a/spec/system/use_presets_spec.rb
+++ b/spec/system/use_presets_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe 'UsePresets', type: :system do
             click_button '検索'
             expect(current_path).to eq inventory_list_use_presets_path(inventory_list)
             expect(page).not_to have_content preset.preset_name
+            expect(page).to have_content 'プリセットがありません'
           end
         end
       end


### PR DESCRIPTION
## 概要

物販購入リストの作成、編集、削除、購入品の作成、編集、削除機能を実装しました。
また、helperに記載していた処理を一部modelに移動しました。

## 確認方法

1. カラムを追加したので `bundle exec rails db:migrate` を実行してください
2. 物販購入リストの作成、編集、削除が行えることを確認してください。また、一覧ページでは物販購入リストの検索が可能なこと、16件以上でページネーションが表示されることを確認してください。
4. 購入品の作成、編集、削除が行えることを確認してください。また、物販購入リストが削除された際にそれに含まれる購入品も削除されることを確認してください。
5. 物販購入リスト詳細ページでは、購入品の値段と個数から金額が表示されること、全ての金額の合計が合計金額として表示されることを確認してください。

## チェックリスト

- [x] rspecrをパスした
