### PR TITLE
デフォルトのプリセット作成機能の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,14 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path, notice: t('.success')
+      begin
+        ActiveRecord::Base.transaction do
+          @user.create_default_preset
+          redirect_to login_path, notice: t('.success')
+        end
+      rescue 
+        redirect_to login_path, notice: t('.missing_create_default_preset')
+      end
     else
       flash.now[:alert] = t('.fail')
       render :new

--- a/app/models/inventory_list.rb
+++ b/app/models/inventory_list.rb
@@ -4,8 +4,6 @@ class InventoryList < ApplicationRecord
 
   validates :inventory_list_name, presence: true
 
-  private
-
   def self.ransackable_attributes(auth_object = nil)
     ['inventory_list_name']
   end

--- a/app/models/item_category.rb
+++ b/app/models/item_category.rb
@@ -4,6 +4,31 @@ class ItemCategory < ApplicationRecord
 
   validates :item_category_name, presence: true, uniqueness: { scope: :preset_id }
 
+  def create_default_items(kinds)
+    case kinds
+    when 'daily'
+      item_names = I18n.t([:charger, :mobile_battery, :handkerchief, :tissue, :medicine, :rain_gear], scope: [:default, :daily_item])
+      item_names.each do |item_name|
+        preset_items.create!(preset_item_name: item_name)
+      end
+    when 'clothing'
+      item_names = I18n.t([:change_clothes, :towel, :cold_weather_gear], scope: [:default, :clothing_item])
+      item_names.each do |item_name|
+        preset_items.create!(preset_item_name: item_name)
+      end
+    when 'live'
+      item_names = I18n.t([:ticket, :penlight, :battery, :live_T_shirt, :live_towel], scope: [:default, :live_item])
+      item_names.each do |item_name|
+        preset_items.create!(preset_item_name: item_name)
+      end
+    when 'valuables'
+      item_names = I18n.t([:wallet, :identification, :IC_card, :smart_phone], scope: [:default, :valuables_item])
+      item_names.each do |item_name|
+        preset_items.create!(preset_item_name: item_name)
+      end
+    end
+  end
+
   def edit?
     ItemCategory.exists?(id: id)
   end

--- a/app/models/preset.rb
+++ b/app/models/preset.rb
@@ -4,7 +4,9 @@ class Preset < ApplicationRecord
 
   validates :preset_name, presence: true
 
-  private
+  def create_default_category(kinds)
+    item_categories.create!(item_category_name: I18n.t("default.item_category.#{kinds}_category"))
+  end
 
   def self.ransackable_attributes(auth_object = nil)
     ['preset_name']

--- a/app/models/purchase_list.rb
+++ b/app/models/purchase_list.rb
@@ -4,8 +4,6 @@ class PurchaseList < ApplicationRecord
 
   validates :purchase_list_name, presence: true
 
-  private
-
   def self.ransackable_attributes(auth_object = nil)
     ['purchase_list_name']
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,22 @@ class User < ApplicationRecord
   validates :email, uniqueness: true
   validates :email, presence: true
   validates :user_name, presence: true, length: { maximum: 20 }
+
+  def create_default_preset
+    daily_preset = presets.create!(preset_name: I18n.t('default.preset.daily_preset'))
+    daily_preset_category = daily_preset.create_default_category('daily')
+    daily_preset_category.create_default_items('daily')
+
+    clothing_preset = presets.create!(preset_name: I18n.t('default.preset.clothing_preset'))
+    clothing_preset_category = clothing_preset.create_default_category('clothing')
+    clothing_preset_category.create_default_items('clothing')
+
+    live_preset = presets.create!(preset_name: I18n.t('default.preset.live_preset'))
+    live_preset_category = live_preset.create_default_category('live')
+    live_preset_category.create_default_items('live')
+
+    valuables_preset = presets.create!(preset_name: I18n.t('default.preset.valuables_preset'))
+    valuables_preset_category = valuables_preset.create_default_category('valuables')
+    valuables_preset_category.create_default_items('valuables')
+  end
 end

--- a/app/views/inventory_lists/index.html.erb
+++ b/app/views/inventory_lists/index.html.erb
@@ -8,10 +8,12 @@
 
 <% if @inventory_lists.present? %>
   <% @inventory_lists.each do |inventory_list| %>
-    <%= inventory_list.inventory_list_name %>
-    <%= link_to t('defaults.show'), inventory_list_path(inventory_list) %>
-    <%= link_to t('defaults.destroy'), inventory_list_path(inventory_list), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: inventory_list.inventory_list_name)} %>
-    <br>
+    <div class = "inventory_list<%= inventory_list.id %>">
+      <%= inventory_list.inventory_list_name %>
+      <%= link_to t('defaults.show'), inventory_list_path(inventory_list) %>
+      <%= link_to t('defaults.destroy'), inventory_list_path(inventory_list), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: inventory_list.inventory_list_name)} %>
+      <br>
+    </div>
   <% end %>
   <%= paginate @inventory_lists %>
 <% else %>

--- a/app/views/presets/index.html.erb
+++ b/app/views/presets/index.html.erb
@@ -8,10 +8,12 @@
 
 <% if @presets.present? %>
   <% @presets.each do |preset| %>
-    <%= preset.preset_name %>
-    <%= link_to t('defaults.show'), preset_path(preset) %>
-    <%= link_to t('defaults.destroy'), preset_path(preset), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: preset.preset_name)} %>
-    <br>
+    <div class = "preset<%= preset.id %>">
+      <%= preset.preset_name %>
+      <%= link_to t('defaults.show'), preset_path(preset) %>
+      <%= link_to t('defaults.destroy'), preset_path(preset), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: preset.preset_name)} %>
+      <br>
+    </div>
   <% end %>
   <%= paginate @presets %>
 <% else %>

--- a/app/views/purchase_lists/index.html.erb
+++ b/app/views/purchase_lists/index.html.erb
@@ -8,10 +8,12 @@
 
 <% if @purchase_lists.present? %>
   <% @purchase_lists.each do |purchase_list| %>
-    <%= purchase_list.purchase_list_name %>
-    <%= link_to t('defaults.show'), purchase_list_path(purchase_list) %>
-    <%= link_to t('defaults.destroy'), purchase_list_path(purchase_list), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: purchase_list.purchase_list_name)} %>
-    <br>
+    <div class = "purchase_list<%= purchase_list.id %>">
+      <%= purchase_list.purchase_list_name %>
+      <%= link_to t('defaults.show'), purchase_list_path(purchase_list) %>
+      <%= link_to t('defaults.destroy'), purchase_list_path(purchase_list), method: :delete, data: {confirm: t('defaults.destroy_confirm', name: purchase_list.purchase_list_name)} %>
+      <br>
+    </div>
   <% end %>
   <%= paginate @purchase_lists %>
 <% else %>

--- a/config/locales/default.ja.yml
+++ b/config/locales/default.ja.yml
@@ -1,0 +1,34 @@
+ja:
+  default:
+    preset:
+      daily_preset: '日用品(デフォルト)'
+      clothing_preset: '衣類(デフォルト)'
+      live_preset: 'ライブ関係(デフォルト)'
+      valuables_preset: '貴重品(デフォルト)'
+    item_category:
+      daily_category: '日用品'
+      clothing_category: '衣類'
+      live_category: 'ライブ関係'
+      valuables_category: '貴重品'
+    daily_item:
+      charger: '充電器'
+      mobile_battery: 'モバイルバッテリー'
+      handkerchief: 'ハンカチ'
+      tissue: 'ティッシュ'
+      medicine: '常備薬'
+      rain_gear: '雨具'
+    clothing_item:
+      change_clothes: '着替え'
+      towel: 'タオル'
+      cold_weather_gear: '防寒具'
+    live_item:
+      ticket: 'チケット'
+      penlight: 'ペンライト'
+      battery: '電池'
+      live_T_shirt: 'ライブTシャツ'
+      live_towel: 'ライブタオル'
+    valuables_item:
+      wallet: '財布'
+      identification: '身分証明'
+      IC_card: 'ICカード'
+      smart_phone: 'スマホ'

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -37,6 +37,7 @@ ja:
     create:
       success: 'ユーザー登録が完了しました'
       fail: 'ユーザー登録に失敗しました'
+      missing_create_default_preset: 'ユーザー登録は成功しましたがデフォルトのプリセットの作成に失敗しました'
   user_sessions:
     new:
       title: 'ログイン'
@@ -174,6 +175,7 @@ ja:
       property_less: 'このカテゴリーに登録された持ち物はありません'
     update:
       success: "%{preset_name}を反映しました"
+      missing_use_preset: 'プリセットの反映時になんらかのエラーが発生したため、処理をロールバックしました。頻発する場合はお問い合せください。'
       preset_category_less: '使用しようとしたプリセットにカテゴリーが登録されていません'
   purchase_lists:
     index:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,7 +82,7 @@ RSpec.configure do |config|
   config.display_try_failure_messages = true
 
   config.around do |ex|
-    ex.run_with_retry retry: 3, retry_wait: 1
+    ex.run_with_retry retry: 2, retry_wait: 1
   end
 
   config.include FactoryBot::Syntax::Methods

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -50,6 +50,60 @@ RSpec.describe 'Users', type: :system do
           expect(page).to have_content 'メールアドレスはすでに存在します'
         end
       end
+      context 'ユーザー登録後' do
+        it 'デフォルトのプリセットが作成されている' do
+          fill_in 'user_user_name', with: 'test_user'
+          fill_in 'user_email', with: 'test@test'
+          fill_in 'user_password', with: 'password'
+          fill_in 'user_password_confirmation', with: 'password'
+          click_button '登録'
+          fill_in 'email', with: 'test@test'
+          fill_in 'password', with: 'password'
+          click_button 'ログイン'
+          visit presets_path
+          expect(page).to have_content '日用品(デフォルト)'
+          expect(page).to have_content '衣類(デフォルト)'
+          expect(page).to have_content 'ライブ関係(デフォルト)'
+          expect(page).to have_content '貴重品(デフォルト)'
+          within ".preset#{Preset.find_by(preset_name: '日用品(デフォルト)').id}" do
+            click_on '詳細'
+          end
+          expect(page).to have_content '日用品'
+          expect(page).to have_content '充電器'
+          expect(page).to have_content 'モバイルバッテリー'
+          expect(page).to have_content 'ハンカチ'
+          expect(page).to have_content 'ティッシュ'
+          expect(page).to have_content '常備薬'
+          expect(page).to have_content '雨具'
+          visit presets_path
+          within ".preset#{Preset.find_by(preset_name: '衣類(デフォルト)').id}" do
+            click_on '詳細'
+          end
+          expect(page).to have_content '衣類'
+          expect(page).to have_content '着替え'
+          expect(page).to have_content 'タオル'
+          expect(page).to have_content '防寒具'
+          visit presets_path
+          within ".preset#{Preset.find_by(preset_name: 'ライブ関係(デフォルト)').id}" do
+            click_on '詳細'
+          end
+          expect(page).to have_content 'ライブ関係'
+          expect(page).to have_content 'チケット'
+          expect(page).to have_content 'ペンライト'
+          expect(page).to have_content '電池'
+          expect(page).to have_content 'ライブTシャツ'
+          expect(page).to have_content 'ライブタオル'
+          visit presets_path
+          within ".preset#{Preset.find_by(preset_name: '貴重品(デフォルト)').id}" do
+            click_on '詳細'
+          end
+          expect(page).to have_content '貴重品'
+          expect(page).to have_content '財布'
+          expect(page).to have_content '身分証明'
+          expect(page).to have_content 'ICカード'
+          expect(page).to have_content 'スマホ'
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要

ユーザー登録時にデフォルトのプリセットが同時に作成される機能を実装しました。
なお、作成されるプリセットは
- プリセット名
  - カテゴリー名
    - 持ち物名

- 日用品(デフォルト)
  - 日用品
    - 充電器
    - モバイルバッテリー
    - ハンカチ
    - ティッシュ
    - 常備薬
    - 雨具
- 衣類(デフォルト)
  - 衣類
    - 着替え
    - タオル
    - 防寒具
- ライブ関係(デフォルト)
  - ライブ関係
    - チケット
    - ペンライト
    - 電池
    - ライブTシャツ
    - ライブタオル
- 貴重品(デフォルト)
  - 貴重品
    - 財布
    - 身分証明
    - ICカード
    - スマホ

の4つになります。

## 確認方法

1. ユーザー登録後に自動的にプリセットが作成されていることを確認してください。

## 影響範囲

処理はuserコントローラーに追加されているためuser周りに影響があるかもしれません。

## チェックリスト

- [x] rspecをパスした
