### PR TITLE
アカウント削除機能の実装

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -14,6 +14,11 @@ class ProfilesController < ApplicationController
     end
   end
 
+  def destroy
+    @user.destroy!
+    redirect_to root_path, notice: t('.success')
+  end
+
   def password_reset; end
 
   def create

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -9,3 +9,4 @@
 <br>
 <%= link_to t('profiles.edit.title'), edit_profile_path %>
 <%= link_to t('profiles.password_reset.title'), password_reset_profile_path %>
+<%= link_to t('.user_destroy'), profile_path, method: :delete, data: {confirm: t('.user_destroy_confirm')} %>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -219,12 +219,16 @@ ja:
   profiles:
     show:
       title: 'プロフィール'
+      user_destroy: 'アカウント削除'
+      user_destroy_confirm: 'アカウント削除後、アカウントの復旧はできません。本当に削除してもよろしいですか?'
     edit:
       title: 'プロフィール編集'
       password_reset: 'パスワード変更'
     update:
       success: 'プロフィールを変更しました'
       fail: 'プロフィールの編集に失敗しました'
+    destroy:
+      success: 'アカウントを削除しました'
     password_reset:
       title: 'パスワード変更用メール送信'
       explanatory: '登録されているメールアドレスにパスワード変更用の

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[new create]
   resources :password_resets, only: %i[new create edit update]
-  resource :profile, only: %i[show edit update create] do
+  resource :profile, only: %i[show edit update destroy create] do
     get 'password_reset', on: :collection
   end
   resources :presets do

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -51,5 +51,23 @@ RSpec.describe 'Profiles', type: :system do
         end
       end
     end
+    context 'アカウント削除' do
+      let!(:preset) { create(:preset, user: user) }
+      let!(:inventory_list) { create(:inventory_list, user: user) }
+      let!(:purchase_list) { create(:purchase_list, user: user) }
+      it 'プロフィール詳細ページでアカウント削除をクリックした場合アカウントが削除される' do
+        visit profile_path
+        click_on 'アカウント削除'
+        expect(page.accept_confirm).to eq 'アカウント削除後、アカウントの復旧はできません。本当に削除してもよろしいですか?'
+        expect(current_path).to eq root_path
+        expect(page).not_to have_content 'プロフィール'
+        expect(page).not_to have_content 'ログアウト'
+        expect(page).to have_content 'ユーザー登録'
+        expect(page).to have_content 'ログイン'
+        expect(Preset.find_by(id: preset.id)).to be nil
+        expect(InventoryList.find_by(id: inventory_list.id)).to be nil
+        expect(PurchaseList.find_by(id: purchase_list.id)).to be nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要

プロフィールページからアカウントを削除できるようにしました。

## 確認方法

1. プロフィールページからアカウントの削除が行えることを確認してください。また、削除時にそのユーザーのプリセットや持ち物リストなどのそのユーザーに関係するものが削除されることを確認してください。

## チェックリスト

- [x] rspecをパスした