### PR TITLE
本番環境のDBをpostgresqlに変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,5 +106,9 @@ group :test do
   gem 'rspec-retry', '~> 0.4.6'
 end
 
+group :production do
+  gem 'pg'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,7 @@ GEM
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)
+    pg (1.5.2)
     popper_js (1.16.1)
     public_suffix (5.0.1)
     puma (5.6.5)
@@ -472,6 +473,7 @@ DEPENDENCIES
   listen (~> 3.3)
   meta-tags
   mysql2 (~> 0.5)
+  pg
   puma (~> 5.0)
   pundit
   rack-mini-profiler (~> 2.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -50,6 +50,7 @@ test:
 #
 production:
   <<: *default
-  database: LIVE_Planning_production
+  adapter: postgresql
+  # database: LIVE_Planning_production
   username: LIVE_Planning
-  password: <%= ENV['LIVE_Planning_DATABASE_PASSWORD'] %> #まだ作ってない
+  password: <%= ENV['LIVE_Planning_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
## 概要

herokuへデプロイするために、本番環境のDBをPostgresqlに変更しました。

## 確認方法

1. 本番環境用のGemを追加したので `bundle install --without production` を実行してください
