### PR TITLE
gemの重複の削除、「bundle lock --add-platform x86_64-linux」の実行

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,6 @@ group :development do
   gem 'rack-mini-profiler', '~> 2.0'
   gem 'listen', '~> 3.3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
   # gem 'solargraph'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.6.2)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
@@ -442,6 +444,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   active_decorator


### PR DESCRIPTION
## 概要

herokuへのデプロイを実行した際のエラーの解消のために、重複していたgem 'spring'の記述を片方削除、「bundle lock --add-platform x86_64-linux」を実行。