### PR TITLE
database.ymlのpuoductionにencodingの設定を追加

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -54,3 +54,4 @@ production:
   # database: LIVE_Planning_production
   username: LIVE_Planning
   password: <%= ENV['LIVE_Planning_DATABASE_PASSWORD'] %>
+  encoding: utf8


### PR DESCRIPTION
## 概要

herokuへのデプロイ後、マイグレーションにてエラーが発生した為解決するために`database.yml`のproductionに`encoding: utf8`の記述を追加しました。