### PR TITLE
property_categoriesのunique制約の名前変更

### DIFF
--- a/db/migrate/20230322110635_create_property_categories.rb
+++ b/db/migrate/20230322110635_create_property_categories.rb
@@ -6,6 +6,6 @@ class CreatePropertyCategories < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
-    add_index :property_categories, [:category_name, :inventory_list_id], unique: true
+    add_index :property_categories, [:category_name, :inventory_list_id], unique: true, name: 'index_property_categories_unique'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 2023_03_29_082457) do
     t.bigint "inventory_list_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["category_name", "inventory_list_id"], name: "index_property_categories_on_category_name_and_inventory_list_id", unique: true
+    t.index ["category_name", "inventory_list_id"], name: "index_property_categories_unique", unique: true
     t.index ["inventory_list_id"], name: "index_property_categories_on_inventory_list_id"
   end
 


### PR DESCRIPTION
## 概要

herokuへのデプロイ後、マイグレーションにてエラーが発生した為解決するために`property_categories`のunique制約を`name`オプションで名前を指定しました。

## 確認方法

1. マイグレーションファイルを編集したので `bundle exec rails db:migrate` を実行してください