### PR TITLE
開発環境でgmailを使用したメール送信のテスト、およびそれらを本番環境に適用

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,4 +77,16 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  #config.action_mailer.raise_delivery_errors = true
+  #config.action_mailer.default_url_options = { host: 'localhost:3000'}
+  #config.action_mailer.delivery_method = :smtp
+  #config.action_mailer.smtp_settings = {
+  #  port: 587,
+  #  address: 'smtp.gmail.com',
+  #  domain: 'gmail.com',
+  #  user_name: ENV['GMAIL_ADDRESS'],
+  #  password: ENV['GMAIL_PASSWORD'],
+  #  authentication: :plain,
+  #  enable_starttls_auto: true
+  #}
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,11 +63,11 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "Enjoy_a_Hobby_production"
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { protocol: 'https', host:'live-planning.herokuapp.com'}
+  config.action_mailer.default_url_options = { host: 'live-planning.herokuapp.com' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     port: 587,
-    address:"smtp.gmail.com",
+    address: 'smtp.gmail.com',
     domain: 'gmail.com',
     user_name: ENV['GMAIL_ADDRESS'],
     password: ENV['GMAIL_PASSWORD'],


### PR DESCRIPTION
## 概要

herokuへのデプロイ後、メールの送信が関わる機能が機能していなかったのでメール周りの設定と修正しましたが、再度機能しなかった為開発環境でgmailを使用したメール送信の確認を行い、本番環境に適用しました。