### PR TITLE
フォームの入力欄に入力されているのが保存できる桁数や文字数を超えた場合にエラーが発生していたのを修正

### DIFF
--- a/app/models/inventory_list.rb
+++ b/app/models/inventory_list.rb
@@ -3,7 +3,7 @@ class InventoryList < ApplicationRecord
   has_many :property_categories, dependent: :destroy
   has_many :schedules, dependent: :nullify
 
-  validates :inventory_list_name, presence: true
+  validates :inventory_list_name, presence: true, length: { maximum: 255 }
 
   def self.ransackable_attributes(auth_object = nil)
     ['inventory_list_name']

--- a/app/models/item_category.rb
+++ b/app/models/item_category.rb
@@ -2,7 +2,7 @@ class ItemCategory < ApplicationRecord
   belongs_to :preset
   has_many :preset_items, dependent: :destroy
 
-  validates :item_category_name, presence: true, uniqueness: { scope: :preset_id }
+  validates :item_category_name, presence: true, uniqueness: { scope: :preset_id }, length: { maximum: 255 }
 
   def create_default_items(kinds)
     case kinds

--- a/app/models/preset.rb
+++ b/app/models/preset.rb
@@ -2,7 +2,7 @@ class Preset < ApplicationRecord
   belongs_to :user
   has_many :item_categories, dependent: :destroy
 
-  validates :preset_name, presence: true
+  validates :preset_name, presence: true, length: { maximum: 255 }
 
   def create_default_category(kinds)
     item_categories.create!(item_category_name: I18n.t("default.item_category.#{kinds}_category"))

--- a/app/models/preset_item.rb
+++ b/app/models/preset_item.rb
@@ -1,7 +1,7 @@
 class PresetItem < ApplicationRecord
   belongs_to :item_category
 
-  validates :preset_item_name, presence: true
+  validates :preset_item_name, presence: true, length: { maximum: 255 }
   
   def edit?
     PresetItem.exists?(id: id)

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,7 +1,7 @@
 class Property < ApplicationRecord
   belongs_to :property_category
 
-  validates :property_name, presence: true
+  validates :property_name, presence: true, length: { maximum: 255 }
 
   def edit?
     Property.exists?(id: id)

--- a/app/models/property_category.rb
+++ b/app/models/property_category.rb
@@ -2,7 +2,7 @@ class PropertyCategory < ApplicationRecord
   belongs_to :inventory_list
   has_many :properties, dependent: :destroy
 
-  validates :category_name, presence: true, uniqueness: { scope: :inventory_list_id }
+  validates :category_name, presence: true, uniqueness: { scope: :inventory_list_id }, length: { maximum: 255 }
 
   def self.find_category(name)
     find_by(category_name: name)

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,9 +1,9 @@
 class Purchase < ApplicationRecord
   belongs_to :purchase_list
 
-  validates :purchase_name, presence: true
-  validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :quantity, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+  validates :purchase_name, presence: true, length: { maximum: 255 }
+  validates :price, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 2147483647 }
+  validates :quantity, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 2147483647 }
 
   def edit?
     Purchase.exists?(id: id)

--- a/app/models/purchase_list.rb
+++ b/app/models/purchase_list.rb
@@ -3,7 +3,7 @@ class PurchaseList < ApplicationRecord
   has_many :purchases, dependent: :destroy
   has_many :schedules, dependent: :nullify
 
-  validates :purchase_list_name, presence: true
+  validates :purchase_list_name, presence: true, length: { maximum: 255 }
 
   def self.ransackable_attributes(auth_object = nil)
     ['purchase_list_name']

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -4,7 +4,10 @@ class Schedule < ApplicationRecord
   belongs_to :purchase_list, optional: true
   has_many :live_times, dependent: :destroy
 
-  validates :schedule_name, presence: true
+  validates :schedule_name, presence: true, length: { maximum: 255 }
+  validates :venue, length: { maximum: 255 }
+  validates :lodging, length: { maximum: 255 }
+  validates :memo, length: { maximum: 65535 }
 
   def self.ransackable_attributes(auth_object = nil)
     ["schedule_name"]

--- a/app/views/purchases/_purchase_form.html.erb
+++ b/app/views/purchases/_purchase_form.html.erb
@@ -7,10 +7,10 @@
     <%= f.text_field :purchase_name, class: 'form-control' %>
 
     <%= f.label :price, class: 'badge badge-primary' %><br>
-    <%= f.number_field :price, min: 0, class: 'form-control' %>
+    <%= f.number_field :price, min: 0, max: 2147483647, class: 'form-control' %>
 
     <%= f.label :quantity, class: 'badge badge-primary' %><br>
-    <%= f.number_field :quantity, min: 1, class: 'form-control' %><br>
+    <%= f.number_field :quantity, min: 1, max: 2147483647, class: 'form-control' %><br>
 
     <% if purchase.edit? %>
       <div class = 'btn-group btn-block'>


### PR DESCRIPTION
## 概要
各フォームの入力欄に保存できない桁数の数字や文字数の文字列が入力されている状態で保存、更新しようとした場合にエラーが発生していたのを修正しました。